### PR TITLE
fix(llm): compute cost after retrieving usage

### DIFF
--- a/src/cognitive_core/llm/provider.py
+++ b/src/cognitive_core/llm/provider.py
@@ -1,64 +1,78 @@
-
 from __future__ import annotations
 
 import os
 
+from .costs import compute_cost_from_usage
+
+try:  # pragma: no cover - runtime optional dependency
+    import requests
+except Exception:  # pragma: no cover - when requests is missing
+    requests = None
+
 
 class LLMProvider:
-    def run(self, prompt: str, **kw) -> dict: raise NotImplementedError
+    def run(self, prompt: str, **kw) -> dict:
+        raise NotImplementedError
+
 
 class MockProvider(LLMProvider):
     name = "mock"
+
     def run(self, prompt: str, **kw):
         return {"text": f"<mock response: {prompt[:200]}>", "_cost_usd": 0.0}
 
+
 class OpenAIAdapter(LLMProvider):
     name = "openai"
-    def __init__(self, key=None, model: str = "gpt-4o-mini"):
-        import os
+
+    def __init__(self, key: str | None = None, model: str = "gpt-4o-mini"):
         self.key = key or os.environ.get("OPENAI_API_KEY")
         self.model = model
 
     def run(self, prompt: str, **kwargs) -> dict:
         # Live implementation using requests. Requires 'requests' package and network access.
-        import os, json
-
-from .costs import compute_cost_from_usage
-
         if not self.key:
             raise RuntimeError("OpenAIAdapter requires OPENAI_API_KEY in environment.")
+
         payload = {
             "model": self.model,
-            "messages": [{"role": "user", "content": prompt}]
+            "messages": [{"role": "user", "content": prompt}],
         }
         headers = {
             "Authorization": f"Bearer {self.key}",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
         base = os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1")
         url = f"{base}/chat/completions"
-        try:
-            import requests
-        except Exception as e:
-            raise RuntimeError("requests package not installed. Install 'requests' to enable OpenAIAdapter.")
+
+        if requests is None:
+            raise RuntimeError(
+                "requests package not installed. Install 'requests' to enable OpenAIAdapter."
+            )
+
         r = requests.post(url, headers=headers, json=payload, timeout=30)
         r.raise_for_status()
         jr = r.json()
+
         text = ""
-        if isinstance(jr, dict) and "choices" in jr and len(jr["choices"])>0:
+        if isinstance(jr, dict) and "choices" in jr and len(jr["choices"]) > 0:
             ch = jr["choices"][0]
             if isinstance(ch.get("message"), dict):
                 text = ch.get("message", {}).get("content") or ch.get("text") or ""
             else:
                 text = ch.get("text") or ""
+
+        usage = jr.get("usage") if isinstance(jr, dict) else None
+
         cost = 0.0
         try:
-            if os.environ.get('ENABLE_COST_CALC','false').lower() in ('1','true','yes') and usage:
+            if os.environ.get("ENABLE_COST_CALC", "false").lower() in ("1", "true", "yes") and usage:
                 cost = compute_cost_from_usage(self.model, usage)
         except Exception:
             cost = 0.0
-        usage = jr.get('usage') if isinstance(jr, dict) else None
+
         return {"text": text, "_cost_usd": cost, "_usage": usage, "_raw": jr}
+
 
 # Provider wrapper will be added by rate_limiter integration
 def get_provider():
@@ -66,3 +80,4 @@ def get_provider():
     if name == "openai":
         return OpenAIAdapter()
     return MockProvider()
+

--- a/src/cognitive_core/llm/provider.py
+++ b/src/cognitive_core/llm/provider.py
@@ -66,7 +66,10 @@ class OpenAIAdapter(LLMProvider):
 
         cost = 0.0
         try:
-            if os.environ.get("ENABLE_COST_CALC", "false").lower() in ("1", "true", "yes") and usage:
+            if (
+                os.environ.get("ENABLE_COST_CALC", "false").lower() in ("1", "true", "yes")
+                and usage
+            ):
                 cost = compute_cost_from_usage(self.model, usage)
         except Exception:
             cost = 0.0
@@ -80,4 +83,3 @@ def get_provider():
     if name == "openai":
         return OpenAIAdapter()
     return MockProvider()
-

--- a/tests/unit/test_llm_provider_cost.py
+++ b/tests/unit/test_llm_provider_cost.py
@@ -31,4 +31,3 @@ def test_cost_computation_with_usage(monkeypatch):
     expected = compute_cost_from_usage(adapter.model, usage)
     assert result["_cost_usd"] == expected
     assert result["_usage"] == usage
-

--- a/tests/unit/test_llm_provider_cost.py
+++ b/tests/unit/test_llm_provider_cost.py
@@ -1,0 +1,34 @@
+from cognitive_core.llm import provider as provider_module
+from cognitive_core.llm.costs import compute_cost_from_usage
+from cognitive_core.llm.provider import OpenAIAdapter
+
+
+def test_cost_computation_with_usage(monkeypatch):
+    usage = {"prompt_tokens": 10, "completion_tokens": 20}
+
+    class DummyResponse:
+        def json(self):
+            return {
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": usage,
+            }
+
+        def raise_for_status(self):
+            pass
+
+    class DummyRequests:
+        @staticmethod
+        def post(url, headers, json, timeout):
+            return DummyResponse()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("ENABLE_COST_CALC", "true")
+    monkeypatch.setattr(provider_module, "requests", DummyRequests)
+
+    adapter = OpenAIAdapter()
+    result = adapter.run("hello")
+
+    expected = compute_cost_from_usage(adapter.model, usage)
+    assert result["_cost_usd"] == expected
+    assert result["_usage"] == usage
+


### PR DESCRIPTION
## Summary
- move imports to top of provider
- compute OpenAI cost only after extracting usage
- add unit test for cost calculation when usage info present

## Testing
- `PYTHONPATH=src pytest tmp_test/test_llm_provider_cost.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c471b5519c8329b7e4917358c0054b