### PR TITLE
Refactor services to use core math utilities

### DIFF
--- a/src/cognitive_core/app/services.py
+++ b/src/cognitive_core/app/services.py
@@ -2,21 +2,19 @@ from __future__ import annotations
 
 from typing import Iterable
 
+from cognitive_core.core.math_utils import dot as _dot, solve_2x2 as _solve_2x2
+
 
 def dot(a: Iterable[float], b: Iterable[float]) -> float:
     a_list = list(a)
     b_list = list(b)
     if len(a_list) != len(b_list):
         raise ValueError("Vectors must be the same length")
-    return float(sum(x * y for x, y in zip(a_list, b_list)))
+    return float(_dot(a_list, b_list))
 
 
 def solve_linear_2x2(
     a11: float, a12: float, a21: float, a22: float, b1: float, b2: float
 ) -> tuple[float, float]:
-    det = a11 * a22 - a12 * a21
-    if det == 0:
-        raise ValueError("Singular matrix")
-    x = (b1 * a22 - b2 * a12) / det
-    y = (a11 * b2 - a21 * b1) / det
+    x, y = _solve_2x2(a11, a12, a21, a22, b1, b2)
     return float(x), float(y)

--- a/tests/test_math_consistency.py
+++ b/tests/test_math_consistency.py
@@ -1,0 +1,39 @@
+import json
+import shlex
+import subprocess
+
+import pytest
+
+from cognitive_core.app import services
+
+
+def _run_cli(args: str):
+    for exe in ("cogctl", "python -m cognitive_core.cli"):
+        proc = subprocess.run(
+            shlex.split(f"{exe} {args}"), capture_output=True, text=True
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            return json.loads(proc.stdout)
+    pytest.skip("CLI not available")
+
+
+@pytest.mark.integration
+def test_dot_consistency(api_client):
+    a = [1.0, 2.0, 3.0]
+    b = [4.0, 5.0, 6.0]
+    service_res = services.dot(a, b)
+    api_res = api_client.post("/api/dot", json={"a": a, "b": b}).json()["result"]
+    cli_res = _run_cli("dotv 1,2,3 4,5,6")["dot"]
+    assert service_res == pytest.approx(api_res)
+    assert service_res == pytest.approx(cli_res)
+
+
+@pytest.mark.integration
+def test_solve2x2_consistency(api_client):
+    params = {"a11": 1, "a12": 1, "a21": 2, "a22": -1, "b1": 4, "b2": 0}
+    service_x, service_y = services.solve_linear_2x2(**params)
+    api_js = api_client.post("/api/solve2x2", json=params).json()
+    cli_js = _run_cli("solve2x2 1 1 2 -1 4 0")
+    assert service_x == pytest.approx(api_js["x"]) == pytest.approx(cli_js["x"])
+    assert service_y == pytest.approx(api_js["y"]) == pytest.approx(cli_js["y"])
+


### PR DESCRIPTION
## Summary
- Delegate service layer math operations to `core.math_utils`
- Add tests ensuring API, CLI, and service layer produce identical math results

## Testing
- `pip install fastapi -q` *(fails: Could not connect to proxy)*
- `pytest tests/test_math_consistency.py -q` *(skipped: fastapi[test] not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c471b6304483298fcc2e9beaebc606