### PR TITLE
Add Solve2x2 request model and validation tests

### DIFF
--- a/src/cognitive_core/api.py
+++ b/src/cognitive_core/api.py
@@ -3,10 +3,20 @@ from typing import Any, Dict, Iterable
 
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
 
 from .core.math_utils import dot, solve_2x2
 
 app = FastAPI(title="cognitive-core-engine")
+
+
+class Solve2x2Request(BaseModel):
+    a: float
+    b: float
+    c: float
+    d: float
+    e: float
+    f: float
 
 
 @app.get("/api/health")
@@ -23,10 +33,8 @@ def dot_api(payload: Dict[str, Iterable[float]]):
 
 
 @app.post("/api/solve2x2")
-def solve2x2_api(payload: Dict[str, float]):
-    x, y = solve_2x2(
-        payload["a"], payload["b"], payload["c"], payload["d"], payload["e"], payload["f"]
-    )
+def solve2x2_api(payload: Solve2x2Request):
+    x, y = solve_2x2(payload.a, payload.b, payload.c, payload.d, payload.e, payload.f)
     return {"x": x, "y": y}
 
 

--- a/tests/test_solve2x2_api.py
+++ b/tests/test_solve2x2_api.py
@@ -3,3 +3,11 @@ def test_solve(api_client):
         "/api/solve2x2", json={"a": 1, "b": 1, "c": 2, "d": -1, "e": 4, "f": 0}
     ).json()
     assert abs(1 * js["x"] + 1 * js["y"] - 4) < 1e-6
+
+
+def test_solve_validation_errors(api_client):
+    for bad_payload in [
+        {"a": 1, "b": 1, "c": 2, "d": -1, "e": 4},
+        {"a": 1, "b": "oops", "c": 2, "d": -1, "e": 4, "f": 0},
+    ]:
+        assert api_client.post("/api/solve2x2", json=bad_payload).status_code == 422


### PR DESCRIPTION
## Summary
- define `Solve2x2Request` Pydantic model with fields a–f
- use typed request model in `/api/solve2x2`
- test validation errors for missing or invalid fields

## Testing
- `python -m py_compile src/cognitive_core/api.py tests/test_solve2x2_api.py`
- `pytest tests/test_solve2x2_api.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68c471b83cdc8329aece5d5f8155e2fa