### PR TITLE
Use dot field in math consistency test

### DIFF
--- a/tests/test_math_consistency.py
+++ b/tests/test_math_consistency.py
@@ -20,10 +20,10 @@ def test_dot_consistency(api_client):
     a = [1.0, 2.0, 3.0]
     b = [4.0, 5.0, 6.0]
     service_res = services.dot(a, b)
-    api_res = api_client.post("/api/dot", json={"a": a, "b": b}).json()["result"]
-    cli_res = _run_cli("dotv 1,2,3 4,5,6")["dot"]
+    api_res = api_client.post("/api/dot", json={"a": a, "b": b}).json()["dot"]
+    cli_res = _run_cli("dotv 1,2,3 4,5,6")
     assert service_res == pytest.approx(api_res)
-    assert service_res == pytest.approx(cli_res)
+    assert service_res == pytest.approx(cli_res["dot"])
 
 
 @pytest.mark.integration

--- a/tests/test_math_consistency.py
+++ b/tests/test_math_consistency.py
@@ -22,8 +22,7 @@ def test_dot_consistency(api_client):
     service_res = services.dot(a, b)
     api_res = api_client.post("/api/dot", json={"a": a, "b": b}).json()["dot"]
     cli_res = _run_cli("dotv 1,2,3 4,5,6")
-    assert service_res == pytest.approx(api_res)
-    assert service_res == pytest.approx(cli_res["dot"])
+    assert service_res == pytest.approx(api_res) == pytest.approx(cli_res["dot"])
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- Ensure dot consistency test checks `dot` value from API response
- Compare service output against CLI `dot` field

## Testing
- `pytest tests/test_math_consistency.py::test_dot_consistency -q` *(fails: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c50a7dd43883298475d04a9af14e2d