### PR TITLE
Support dual solve2x2 parameter formats

### DIFF
--- a/tests/test_math_consistency.py
+++ b/tests/test_math_consistency.py
@@ -27,10 +27,17 @@ def test_dot_consistency(api_client):
 
 
 @pytest.mark.integration
-def test_solve2x2_consistency(api_client):
+@pytest.mark.parametrize(
+    "api_payload",
+    [
+        {"a11": 1, "a12": 1, "a21": 2, "a22": -1, "b1": 4, "b2": 0},
+        {"a": 1, "b": 1, "c": 2, "d": -1, "e": 4, "f": 0},
+    ],
+)
+def test_solve2x2_consistency(api_client, api_payload):
     params = {"a11": 1, "a12": 1, "a21": 2, "a22": -1, "b1": 4, "b2": 0}
     service_x, service_y = services.solve_linear_2x2(**params)
-    api_js = api_client.post("/api/solve2x2", json=params).json()
+    api_js = api_client.post("/api/solve2x2", json=api_payload).json()
     cli_js = _run_cli("solve2x2 1 1 2 -1 4 0")
     assert service_x == pytest.approx(api_js["x"]) == pytest.approx(cli_js["x"])
     assert service_y == pytest.approx(api_js["y"]) == pytest.approx(cli_js["y"])

--- a/tests/test_solve2x2_api.py
+++ b/tests/test_solve2x2_api.py
@@ -1,5 +1,14 @@
-def test_solve(api_client):
-    js = api_client.post(
-        "/api/solve2x2", json={"a": 1, "b": 1, "c": 2, "d": -1, "e": 4, "f": 0}
-    ).json()
-    assert abs(1 * js["x"] + 1 * js["y"] - 4) < 1e-6
+import pytest
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"a": 1, "b": 1, "c": 2, "d": -1, "e": 4, "f": 0},
+        {"a11": 1, "a12": 1, "a21": 2, "a22": -1, "b1": 4, "b2": 0},
+    ],
+)
+def test_solve(api_client, payload):
+    js = api_client.post("/api/solve2x2", json=payload).json()
+    assert 1 * js["x"] + 1 * js["y"] == pytest.approx(4)
+    assert 2 * js["x"] - 1 * js["y"] == pytest.approx(0)


### PR DESCRIPTION
## Summary
- map legacy `a,b,c,d,e,f` keys to `a11,a12,a21,a22,b1,b2` for the `/api/solve2x2` endpoint
- delegate solving to `services.solve_linear_2x2`
- test API and service consistency for both parameter formats

## Testing
- `pytest tests/test_solve2x2_api.py::test_solve -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68c50a8252c483298fc754fc5711d4ac