### PR TITLE
Add API models with validation and tests

### DIFF
--- a/src/cognitive_core/api.py
+++ b/src/cognitive_core/api.py
@@ -1,33 +1,54 @@
 import time
-from typing import Any, Dict, Iterable
+from typing import Any
 
 from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
 
 from .core.math_utils import dot, solve_2x2
+
+
+class DotRequest(BaseModel):
+    a: list[float]
+    b: list[float]
+
+
+class DotResponse(BaseModel):
+    dot: float
+
+
+class Solve2x2Request(BaseModel):
+    a: float
+    b: float
+    c: float
+    d: float
+    e: float
+    f: float
+
+
+class Solve2x2Response(BaseModel):
+    x: float
+    y: float
+
 
 app = FastAPI(title="cognitive-core-engine")
 
 
 @app.get("/api/health")
-def health() -> Dict[str, Any]:
+def health() -> dict[str, Any]:
     return {"status": "ok", "name": "cognitive-core-engine"}
 
 
-@app.post("/api/dot")
-def dot_api(payload: Dict[str, Iterable[float]]):
-    a = payload.get("a", [])
-    b = payload.get("b", [])
-    n = min(len(a), len(b))
-    return {"dot": dot(a[:n], b[:n])}
+@app.post("/api/dot", response_model=DotResponse)
+def dot_api(req: DotRequest) -> DotResponse:
+    n = min(len(req.a), len(req.b))
+    return DotResponse(dot=dot(req.a[:n], req.b[:n]))
 
 
-@app.post("/api/solve2x2")
-def solve2x2_api(payload: Dict[str, float]):
-    x, y = solve_2x2(
-        payload["a"], payload["b"], payload["c"], payload["d"], payload["e"], payload["f"]
-    )
-    return {"x": x, "y": y}
+@app.post("/api/solve2x2", response_model=Solve2x2Response)
+def solve2x2_api(req: Solve2x2Request) -> Solve2x2Response:
+    x, y = solve_2x2(req.a, req.b, req.c, req.d, req.e, req.f)
+    return Solve2x2Response(x=x, y=y)
 
 
 def _sse_gen():

--- a/tests/test_dot_api.py
+++ b/tests/test_dot_api.py
@@ -1,2 +1,19 @@
+import pytest
+
+
 def test_dot(api_client):
-    assert api_client.post("/api/dot", json={"a": [1, 2, 3], "b": [4, 5, 6]}).json()["dot"] == 32.0
+    assert (
+        api_client.post("/api/dot", json={"a": [1, 2, 3], "b": [4, 5, 6]}).json()["dot"]
+        == 32.0
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"a": [1, 2]},  # missing b
+        {"a": [1, 2], "b": [3, "x"]},  # non-numeric value
+    ],
+)
+def test_dot_validation_errors(api_client, payload):
+    assert api_client.post("/api/dot", json=payload).status_code == 422

--- a/tests/test_solve2x2_api.py
+++ b/tests/test_solve2x2_api.py
@@ -1,5 +1,19 @@
+import pytest
+
+
 def test_solve(api_client):
     js = api_client.post(
         "/api/solve2x2", json={"a": 1, "b": 1, "c": 2, "d": -1, "e": 4, "f": 0}
     ).json()
     assert abs(1 * js["x"] + 1 * js["y"] - 4) < 1e-6
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"a": 1, "b": 1, "c": 2, "d": -1, "e": 4},  # missing f
+        {"a": "bad", "b": 1, "c": 2, "d": -1, "e": 4, "f": 0},  # non-numeric a
+    ],
+)
+def test_solve_validation_errors(api_client, payload):
+    assert api_client.post("/api/solve2x2", json=payload).status_code == 422


### PR DESCRIPTION
## Summary
- add Pydantic request/response models for dot and 2x2 solver endpoints
- return structured responses from `/api/dot` and `/api/solve2x2`
- test validation for missing or non-numeric fields

## Testing
- `pytest tests/test_dot_api.py tests/test_solve2x2_api.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68c50a857a0c832994e28434609b87d0