### PR TITLE
chore: route imports through api package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 COPY . /app
 RUN pip install --upgrade pip && pip install --no-cache-dir requests httpx redis sqlalchemy alembic psycopg2-binary prometheus-client structlog
 EXPOSE 8000
-CMD ["uvicorn", "cognitive_core.api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "cognitive_core.api:app", "--host", "0.0.0.0", "--port", "8000"]
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD python -c "import urllib.request as u; u.urlopen('http://127.0.0.1:8000/health')" || exit 1

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test:
 	pytest
 
 api:
-	uvicorn cognitive_core.api.main:app --host 0.0.0.0 --port 8000 --reload
+        uvicorn cognitive_core.api:app --host 0.0.0.0 --port 8000 --reload
 
 docs:
 	mkdocs build --strict || true

--- a/deployment/cognitive_core.service
+++ b/deployment/cognitive_core.service
@@ -10,7 +10,7 @@ WorkingDirectory=/opt/cognitive-core
 Environment=DATABASE_URL=postgresql+psycopg2://cce:cce@localhost:5432/cce
 Environment=REDIS_URL=redis://localhost:6379/0
 Environment=API_KEY=changeme
-ExecStart=/opt/cognitive-core/.venv/bin/uvicorn cognitive_core.api.main:app --host 0.0.0.0 --port 8000
+ExecStart=/opt/cognitive-core/.venv/bin/uvicorn cognitive_core.api:app --host 0.0.0.0 --port 8000
 Restart=on-failure
 RestartSec=5s
 

--- a/tests/compat/test_api_contract.py
+++ b/tests/compat/test_api_contract.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from cognitive_core.api.main import app
+from cognitive_core.api import app
 
 client = TestClient(app)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ try:
     from fastapi.testclient import TestClient  # type: ignore
 except Exception:
     pytest.skip("fastapi[test] not installed; skipping API tests", allow_module_level=True)
-from cognitive_core.api.main import app
+from cognitive_core.api import app
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from cognitive_core.api.main import app
+from cognitive_core.api import app
 
 client = TestClient(app)
 


### PR DESCRIPTION
## Summary
- simplify references to FastAPI app by importing it from the `cognitive_core.api` package
- adjust infrastructure files to use `cognitive_core.api:app`
- update tests to rely on package export

## Testing
- `make lint` *(fails: Import block is un-sorted or un-formatted)*
- `ruff check tests/e2e/test_api.py tests/conftest.py tests/compat/test_api_contract.py`
- `pytest` *(skipped: fastapi[test] not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c516c1bc408329b6296677335e4df3