### PR TITLE
chore: add universal ci cd

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,12 @@
+name: Bug Report
+description: File a bug report
+labels: ["type/ci"]
+body:
+  - type: textarea
+    id: bug
+    attributes:
+      label: What happened?
+      description: Describe the bug
+      placeholder: Steps to reproduce
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,12 @@
+name: Feature Request
+description: Suggest an idea
+labels: ["type/ci"]
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: Proposal
+      description: What do you want?
+      placeholder: Describe the feature
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+## Checklist
+- [ ] Tests added/updated
+- [ ] CI green
+- [ ] Security tools passed
+- [ ] Docs updated

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "go"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,12 @@
+- name: type/ci
+  color: 0e8a16
+  description: CI related changes
+- name: type/security
+  color: d93f0b
+  description: Security related changes
+- name: env/preview
+  color: 5319e7
+  description: Preview environment
+- name: env/release
+  color: 0366d6
+  description: Release environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,105 +2,309 @@ name: CI
 
 on:
   push:
+    branches: ['**']
   pull_request:
+    branches: ['**']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
-  setup:
+  detect:
     runs-on: ubuntu-latest
-    steps:
-      - run: echo "setup"
-  lint:
-    needs: setup
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write   # потрібно, щоб автокомітнути зміни форматування
+    outputs:
+      has_python: ${{ steps.detect.outputs.has_python }}
+      has_node: ${{ steps.detect.outputs.has_node }}
+      has_go: ${{ steps.detect.outputs.has_go }}
+      has_java: ${{ steps.detect.outputs.has_java }}
+      has_rust: ${{ steps.detect.outputs.has_rust }}
+      has_docker: ${{ steps.detect.outputs.has_docker }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with: { python-version: '3.12' }
-      - name: Install deps
+      - id: detect
         run: |
-          python -m pip install -U pip setuptools wheel
-          pip install -e ".[dev]" || pip install ruff black isort
-      - name: Auto-format (ruff+black+isort)
-        run: |
-          ruff check . --fix || true
-          black . || true
-          isort . || true
-      - name: Auto-commit formatting
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "style(fmt): auto-format via CI (ruff/black/isort)"
-          commit_user_name: bot-ci
-          commit_user_email: bot@example.com
-          skip_dirty_check: false
-      - name: Ruff (verify)
-        run: ruff check .
-      - name: Black (verify)
-        run: black --check .
-      - name: isort (verify)
-        run: isort --check-only .
+          echo "has_python=false" >> $GITHUB_OUTPUT
+          echo "has_node=false" >> $GITHUB_OUTPUT
+          echo "has_go=false" >> $GITHUB_OUTPUT
+          echo "has_java=false" >> $GITHUB_OUTPUT
+          echo "has_rust=false" >> $GITHUB_OUTPUT
+          echo "has_docker=false" >> $GITHUB_OUTPUT
+          [ -f requirements.txt ] || [ -f pyproject.toml ] && echo "has_python=true" >> $GITHUB_OUTPUT
+          [ -f package.json ] && echo "has_node=true" >> $GITHUB_OUTPUT
+          [ -f go.mod ] && echo "has_go=true" >> $GITHUB_OUTPUT
+          [ -f pom.xml ] && echo "has_java=true" >> $GITHUB_OUTPUT
+          [ -f Cargo.toml ] && echo "has_rust=true" >> $GITHUB_OUTPUT
+          [ -f Dockerfile ] && echo "has_docker=true" >> $GITHUB_OUTPUT
 
-  typecheck:
+  python:
+    needs: detect
+    if: needs.detect.outputs.has_python == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-      - name: Install deps
+          python-version: '3.11'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/pyproject.toml') }}
+          restore-keys: ${{ runner.os }}-pip-
+      - name: Install dependencies
         run: |
-          python -m pip install -U pip setuptools wheel
-          pip install -e ".[api,test,dev,security,docs]" || pip install -e .
+          python -m pip install -U pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f pyproject.toml ]; then pip install .; fi
+          pip install ruff mypy bandit safety pytest coverage
+      - name: Ruff
+        run: ruff --output-format=github .
       - name: Mypy
         run: mypy .
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install deps
-        run: |
-          python -m pip install -U pip setuptools wheel
-          pip install -e ".[api,test,dev,security,docs]" || pip install -e .
-      - name: Pytest
-        run: pytest -q
-
-  security:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install deps
-        run: |
-          python -m pip install -U pip setuptools wheel
-          pip install -e ".[api,test,dev,security,docs]" || pip install -e .
       - name: Bandit
-        run: bandit -r .
-      - name: Pip Audit
-        run: pip-audit --skip-deps --strict
+        run: bandit -r . -f xml -o reports/bandit.xml || true
+      - name: Safety
+        run: safety check --full-report --json > reports/safety.json || true
+      - name: Pytest
+        run: pytest --junitxml=reports/junit-python.xml --cov=. --cov-report=xml
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-reports
+          path: |
+            coverage.xml
+            reports/junit-python.xml
+            reports/bandit.xml
+            reports/safety.json
 
-  docs:
+  node:
+    needs: detect
+    if: needs.detect.outputs.has_node == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-node@v4
         with:
-          python-version: "3.11"
-      - name: Install deps
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci || npm i
+      - name: ESLint
+        run: npx eslint . || true
+      - name: Typecheck
+        run: npx tsc -p . || true
+      - name: NPM Audit
+        run: npm audit --json > reports/npm-audit.json || true
+      - name: Jest
+        run: npx jest --ci --reporters=default --reporters=jest-junit --coverage
+        env:
+          JEST_JUNIT_OUTPUT_DIR: reports
+          JEST_JUNIT_OUTPUT_NAME: junit-node.xml
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: node-reports
+          path: |
+            coverage/lcov.info
+            reports/junit-node.xml
+            reports/npm-audit.json
+
+  go:
+    needs: detect
+    if: needs.detect.outputs.has_go == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./... -coverprofile=cover.out -json > reports/go-test.json
+      - name: Coverage
+        run: go tool cover -func=cover.out
+      - name: Govulncheck
         run: |
-          python -m pip install -U pip setuptools wheel
-          pip install -e ".[api,test,dev,security,docs]" || pip install -e .
-      - name: Build docs
-        run: mkdocs build --strict
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck -json ./... > reports/govulncheck.json || true
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-reports
+          path: |
+            cover.out
+            reports/go-test.json
+            reports/govulncheck.json
+
+  java:
+    needs: detect
+    if: needs.detect.outputs.has_java == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+      - name: Maven verify
+        run: mvn -B -DskipITs=true verify
+      - name: OWASP dependency check
+        run: mvn -B org.owasp:dependency-check-maven:check || true
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: java-reports
+          path: |
+            **/target/surefire-reports/*.xml
+            **/target/site/jacoco/jacoco.xml
+            **/target/dependency-check-report.xml
+
+  rust:
+    needs: detect
+    if: needs.detect.outputs.has_rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings || true
+      - name: Test
+        run: cargo test --all -- --format=json --report-time | tee reports/rust-test.json
+      - name: Coverage
+        run: cargo tarpaulin --out Xml || true
+      - name: Cargo audit
+        run: cargo audit --json > reports/cargo-audit.json || true
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-reports
+          path: |
+            cobertura.xml
+            reports/rust-test.json
+            reports/cargo-audit.json
+
+  docker:
+    needs: detect
+    if: needs.detect.outputs.has_docker == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-
+      - name: Login GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build and push
+        run: |
+          IMAGE=ghcr.io/${{ github.repository }}
+          TAG_BRANCH=${{ github.ref_name }}
+          TAG_SHA=${{ github.sha }}
+          TAGS="--tag $IMAGE:$TAG_BRANCH --tag $IMAGE:$TAG_SHA"
+          if [ "${{ github.ref }}" = "refs/heads/${{ github.event.repository.default_branch }}" ]; then
+            TAGS="$TAGS --tag $IMAGE:latest"
+          fi
+          docker buildx build . --push --platform linux/amd64,linux/arm64 $TAGS --cache-from type=local,src=/tmp/.buildx-cache --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max
+      - name: Move cache
+        if: always()
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  pages:
+    needs: detect
+    if: needs.detect.outputs.has_node == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Build
+        run: |
+          if [ -f package.json ]; then
+            npm ci || npm i
+            if node -e "process.exit(!(require('./package.json').scripts && require('./package.json').scripts.build))"; then
+              npm run build
+            fi
+          fi
+      - name: Detect static
+        id: static
+        run: |
+          if [ -d dist ]; then echo "path=dist" >> $GITHUB_OUTPUT; \
+          elif [ -d build ]; then echo "path=build" >> $GITHUB_OUTPUT; \
+          else echo "path=" >> $GITHUB_OUTPUT; fi
+      - name: Upload artifact
+        if: steps.static.outputs.path != ''
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ steps.static.outputs.path }}
+      - name: Deploy
+        if: steps.static.outputs.path != ''
+        uses: actions/deploy-pages@v4
+        id: deploy
+      environment:
+        name: github-pages
+        url: ${{ steps.deploy.outputs.page_url }}
+
+  summary:
+    needs: [python, node, go, java, rust, docker, pages]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          cat <<'EOF' >> $GITHUB_STEP_SUMMARY
+          | Job | Result |
+          | --- | --- |
+          | python | ${{ needs.python.result }} |
+          | node | ${{ needs.node.result }} |
+          | go | ${{ needs.go.result }} |
+          | java | ${{ needs.java.result }} |
+          | rust | ${{ needs.rust.result }} |
+          | docker | ${{ needs.docker.result }} |
+          | pages | ${{ needs.pages.result }} |
+          EOF

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,29 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, python, go, java-kotlin, cpp, ruby]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - uses: github/codeql-action/autobuild@v3
+      - uses: github/codeql-action/analyze@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-json
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.5
+    hooks:
+      - id: ruff
+        args: [--fix]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-requests]
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,48 @@
-.PHONY: setup lint test api docs build cov docker dev
+
+.PHONY: setup lint test coverage security fmt api docs build docker dev
 
 setup:
-	python -m venv .venv && . .venv/bin/activate && pip install -U pip && pip install -e .[dev] && pre-commit install
+	@if [ -f requirements.txt ] || [ -f pyproject.toml ]; then \
+		python -m pip install -U pip && pip install -e .[dev] || pip install -r requirements.txt; \
+	fi
+	@if [ -f package.json ]; then npm install; fi
+	@if [ -f go.mod ]; then go mod download; fi
+	@if [ -f Cargo.toml ]; then cargo fetch; fi
+	@if [ -f pom.xml ]; then mvn -B dependency:resolve || true; fi
 
 lint:
-	ruff check . && ruff format --check . && isort --check-only . && black --check .
+	@if [ -f requirements.txt ] || [ -f pyproject.toml ]; then ruff . && mypy . && bandit -r . || true; fi
+	@if [ -f package.json ]; then npx eslint . || true && npx tsc -p . || true; fi
+	@if [ -f go.mod ]; then go vet ./...; fi
+	@if [ -f Cargo.toml ]; then cargo clippy --all-targets --all-features -- -D warnings || true; fi
+	@if [ -f pom.xml ]; then mvn -B -q verify -DskipTests; fi
 
 test:
-	pytest
+	@if [ -f requirements.txt ] || [ -f pyproject.toml ]; then pytest; fi
+	@if [ -f package.json ]; then npx jest; fi
+	@if [ -f go.mod ]; then go test ./...; fi
+	@if [ -f Cargo.toml ]; then cargo test; fi
+	@if [ -f pom.xml ]; then mvn -B test; fi
+
+coverage:
+	@if [ -f requirements.txt ] || [ -f pyproject.toml ]; then pytest --cov=. --cov-report=xml; fi
+	@if [ -f package.json ]; then npx jest --coverage; fi
+	@if [ -f go.mod ]; then go test ./... -coverprofile=cover.out; fi
+	@if [ -f Cargo.toml ]; then cargo tarpaulin --out Xml || true; fi
+	@if [ -f pom.xml ]; then mvn -B jacoco:report; fi
+
+security:
+	@if [ -f requirements.txt ] || [ -f pyproject.toml ]; then bandit -r . && safety check || true; fi
+	@if [ -f package.json ]; then npm audit || true; fi
+	@if [ -f go.mod ]; then govulncheck ./... || true; fi
+	@if [ -f Cargo.toml ]; then cargo audit || true; fi
+	@if [ -f pom.xml ]; then mvn -B org.owasp:dependency-check-maven:check || true; fi
+
+fmt:
+	@if [ -f requirements.txt ] || [ -f pyproject.toml ]; then ruff --fix . && black .; fi
+	@if [ -f package.json ]; then npx eslint . --fix || true; fi
+	@if [ -f go.mod ]; then find . -name '*.go' -print0 | xargs -0 gofmt -w; fi
+	@if [ -f Cargo.toml ]; then cargo fmt; fi
 
 api:
 	uvicorn cognitive_core.api.main:app --host 0.0.0.0 --port 8000 --reload
@@ -17,9 +52,6 @@ docs:
 
 build:
 	python -m build || true
-
-cov:
-	pytest --cov=src/cognitive_core --cov-report=xml
 
 docker:
 	docker build -t cognitive-core:local .

--- a/README-TESTING.md
+++ b/README-TESTING.md
@@ -1,0 +1,16 @@
+# Testing & CI/CD
+
+Use the provided `Makefile` for local workflows:
+
+```
+make setup
+make lint
+make test
+make coverage
+make security
+make fmt
+```
+
+GitHub Actions runs on every push and pull request. The pipeline auto-detects the project stack and executes linting, type checking, unit tests with coverage, and security scans. Reports (JUnit, coverage, and security) are uploaded as workflow artifacts.
+
+Container images are built for each branch and commit and published to GHCR with tags matching the branch name and commit SHA; the default branch also receives the `latest` tag. If a Node build outputs a static site, a preview is deployed to GitHub Pages for that branch.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  testMatch: ['**/tests/node/**/*.spec.ts'],
+  reporters: [
+    'default',
+    ['jest-junit', { outputDirectory: 'reports', outputName: 'junit-node.xml' }]
+  ],
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageReporters: ['lcov', 'text'],
+};
+
+export default config;

--- a/tests/go/sanity_test.go
+++ b/tests/go/sanity_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func TestSanity(t *testing.T) {
+    if 2+2 != 4 {
+        t.Fatal("math broken")
+    }
+}

--- a/tests/java/src/test/java/app/SanityTest.java
+++ b/tests/java/src/test/java/app/SanityTest.java
@@ -1,0 +1,11 @@
+package app;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SanityTest {
+    @Test
+    void sanity() {
+        assertEquals(4, 2 + 2);
+    }
+}

--- a/tests/node/sanity.spec.ts
+++ b/tests/node/sanity.spec.ts
@@ -1,0 +1,5 @@
+describe('sanity', () => {
+  it('adds', () => {
+    expect(2 + 2).toBe(4);
+  });
+});

--- a/tests/python/test_sanity.py
+++ b/tests/python/test_sanity.py
@@ -1,0 +1,2 @@
+def test_sanity():
+    assert 2 + 2 == 4

--- a/tests/rust/sanity.rs
+++ b/tests/rust/sanity.rs
@@ -1,0 +1,4 @@
+#[test]
+fn sanity() {
+    assert_eq!(2 + 2, 4);
+}


### PR DESCRIPTION
## Summary
- add polyglot CI/CD workflow with auto-detection, artifacts, docker builds, and pages previews
- enable CodeQL scanning
- add pre-commit, Makefile parity, testing docs, scaffolds, labels, templates, and dependabot

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/codeql.yml .pre-commit-config.yaml Makefile README-TESTING.md tests/python/test_sanity.py tests/node/sanity.spec.ts jest.config.ts tests/go/sanity_test.go tests/java/src/test/java/app/SanityTest.java tests/rust/sanity.rs .github/labels.yml .github/dependabot.yml .github/PULL_REQUEST_TEMPLATE.md .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml` *(failed: command not found)*
- `pip install pre-commit` *(failed: 403 Forbidden)*
- `pytest tests/python/test_sanity.py -vv` *(failed: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c53b7d63788329be7800a4bf40dcc0