### PR TITLE
docs: polish README and add asset stubs

### DIFF
--- a/ASSETS-TODO.md
+++ b/ASSETS-TODO.md
@@ -6,7 +6,6 @@ This checklist tracks visual assets that need to be produced manually.
 - [ ] `media/api-demo.gif` — 10–15s screencast showing API request/response.
 - [ ] `media/cli-demo.gif` — 10–15s screencast of `cogctl` basic usage.
 - [ ] Replace `assets/logo.svg` with final logo design if available.
-- [ ] Replace `OWNER/REPO` placeholders in README badges with the actual repository slug.
 
 ## Capture commands
 

--- a/ASSETS-TODO.md
+++ b/ASSETS-TODO.md
@@ -1,0 +1,16 @@
+# Assets TODO
+
+This checklist tracks visual assets that need to be produced manually.
+
+- [ ] `assets/og-banner.png` — 1280x640 social preview banner.
+- [ ] `media/api-demo.gif` — 10–15s screencast showing API request/response.
+- [ ] `media/cli-demo.gif` — 10–15s screencast of `cogctl` basic usage.
+- [ ] Replace `assets/logo.svg` with final logo design if available.
+- [ ] Replace `OWNER/REPO` placeholders in README badges with the actual repository slug.
+
+## Capture commands
+
+```bash
+# Example using ffmpeg to record terminal
+ffmpeg -f x11grab -video_size 1280x720 -i "$DISPLAY" -t 15 media/cli-demo.gif
+```

--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 
 > Базовий рушій для когнітивних сервісів із API, CLI та підтримкою плагінів.
 
-[![CI](https://img.shields.io/github/actions/workflow/status/neuron7x/cognitive-core-engine/ci.yml?style=flat-square&logo=github)](https://github.com/neuron7x/cognitive-core-engine/actions/workflows/ci.yml)
-[![CodeQL](https://img.shields.io/github/actions/workflow/status/neuron7x/cognitive-core-engine/codeql.yml?style=flat-square&logo=github)](https://github.com/neuron7x/cognitive-core-engine/actions/workflows/codeql.yml)
-[![Python](https://img.shields.io/badge/python-3.10%2B-blue?style=flat-square&logo=python)](#)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green?style=flat-square)](LICENSE)
+[![CI](https://img.shields.io/github/actions/workflow/status/neuron7x/cognitive-core-engine/ci.yml?style=flat-square&logo=github)](https://github.com/neuron7x/cognitive-core-engine/actions/workflows/ci.yml) [![CodeQL](https://img.shields.io/github/actions/workflow/status/neuron7x/cognitive-core-engine/codeql.yml?style=flat-square&logo=github)](https://github.com/neuron7x/cognitive-core-engine/actions/workflows/codeql.yml) [![Python](https://img.shields.io/badge/python-3.10%2B-blue?style=flat-square&logo=python)](#) [![License: MIT](https://img.shields.io/badge/license-MIT-green?style=flat-square)](LICENSE)
 <!-- [![PyPI](https://img.shields.io/pypi/v/cognitive-core-engine?style=flat-square&logo=pypi)](https://pypi.org/project/cognitive-core-engine/) -->
 <!-- [![Coverage](https://img.shields.io/badge/coverage-??%25-lightgrey?style=flat-square)](# "verification required") -->
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,37 @@
-# cognitive-core-engine
+# <img src="assets/logo.svg" alt="Логотип" width="48" align="left"/> cognitive-core-engine
+
+> Базовий рушій для когнітивних сервісів із API, CLI та підтримкою плагінів.
+
+[![CI](https://img.shields.io/github/actions/workflow/status/OWNER/REPO/ci.yml?style=flat-square&logo=github)](https://github.com/OWNER/REPO/actions/workflows/ci.yml) <!-- TODO: replace OWNER/REPO with actual slug -->
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/OWNER/REPO/codeql.yml?style=flat-square&logo=github)](https://github.com/OWNER/REPO/actions/workflows/codeql.yml) <!-- TODO: replace OWNER/REPO with actual slug -->
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue?style=flat-square&logo=python)](#)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green?style=flat-square)](LICENSE)
+<!-- [![PyPI](https://img.shields.io/pypi/v/cognitive-core-engine?style=flat-square&logo=pypi)](https://pypi.org/project/cognitive-core-engine/) -->
+<!-- [![Coverage](https://img.shields.io/badge/coverage-??%25-lightgrey?style=flat-square)](# "verification required") -->
+
+## Зміст
+- [Огляд](#огляд)
+- [Особливості](#особливості)
+- [Встановлення](#встановлення)
+- [Швидкий старт](#швидкий-старт)
+  - [API](#api)
+  - [CLI](#cli)
+- [Тестування](#тестування)
+- [Архітектура](#архітектура)
+- [Дорожня карта](#дорожня-карта)
+- [Документація](#документація)
+- [Спільнота](#спільнота)
+- [Ліцензія](#ліцензія)
 
 ## Огляд
-`cognitive-core-engine` забезпечує базові компоненти для побудови та виконання когнітивних сервісів. Проєкт включає API, CLI та інструменти для розробки.
+`cognitive-core-engine` забезпечує базові компоненти для побудови та виконання когнітивних сервісів.
+Проєкт включає API, CLI та інструменти для розробки.
+
+## Особливості
+- Відкритий HTTP API на FastAPI
+- CLI `cogctl`
+- Плагінна система
+- Тести та CI
 
 ## Встановлення
 ```bash
@@ -27,6 +57,39 @@ cogctl --help
 pytest
 ```
 
+## Архітектура
+```mermaid
+graph TD
+    subgraph Domain
+        D[Entities]
+    end
+    subgraph Application
+        A[Use Cases]
+    end
+    subgraph Interfaces
+        I[FastAPI]
+        C[CLI]
+    end
+    D --> A --> I
+    A --> C
+    A --> P[Plugins]
+```
+
+## Дорожня карта
+- [ ] Опублікувати першу версію на PyPI
+- [ ] Розширити каталог плагінів
+- [ ] Додати приклади використання
+
 ## Документація
 Докладніше у [docs/](docs/).
 
+## Спільнота
+- [Посібник для контриб'юторів](CONTRIBUTING.md)
+- [Кодекс поведінки](CODE_OF_CONDUCT.md)
+- [Політика безпеки](SECURITY.md)
+
+## Ліцензія
+Цей проєкт розповсюджується за ліцензією [MIT](LICENSE).
+
+---
+*Готово до вкладу: приймаємо PR та пропозиції!* 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 > Базовий рушій для когнітивних сервісів із API, CLI та підтримкою плагінів.
 
-[![CI](https://img.shields.io/github/actions/workflow/status/OWNER/REPO/ci.yml?style=flat-square&logo=github)](https://github.com/OWNER/REPO/actions/workflows/ci.yml) <!-- TODO: replace OWNER/REPO with actual slug -->
-[![CodeQL](https://img.shields.io/github/actions/workflow/status/OWNER/REPO/codeql.yml?style=flat-square&logo=github)](https://github.com/OWNER/REPO/actions/workflows/codeql.yml) <!-- TODO: replace OWNER/REPO with actual slug -->
+[![CI](https://img.shields.io/github/actions/workflow/status/neuron7x/cognitive-core-engine/ci.yml?style=flat-square&logo=github)](https://github.com/neuron7x/cognitive-core-engine/actions/workflows/ci.yml)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/neuron7x/cognitive-core-engine/codeql.yml?style=flat-square&logo=github)](https://github.com/neuron7x/cognitive-core-engine/actions/workflows/codeql.yml)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue?style=flat-square&logo=python)](#)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green?style=flat-square)](LICENSE)
 <!-- [![PyPI](https://img.shields.io/pypi/v/cognitive-core-engine?style=flat-square&logo=pypi)](https://pypi.org/project/cognitive-core-engine/) -->

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="15" fill="#3b82f6"/>
+  <text x="50" y="55" font-size="50" text-anchor="middle" fill="#ffffff" font-family="Arial, sans-serif">CC</text>
+</svg>


### PR DESCRIPTION
## Summary
- revamp README with logo, badges, feature overview, roadmap, and mermaid architecture diagram
- add placeholder logo SVG and checklist for social banner and demo gifs
- clarify repository slug placeholders in badges

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install 'fastapi>=0.111' 'httpx>=0.25' -q` *(fails: Could not find a version that satisfies the requirement fastapi>=0.111)*

------
https://chatgpt.com/codex/tasks/task_e_68c547f73f408329957a10b3c2f4da53