### PR TITLE
docs: link Python badge to python.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CI](https://img.shields.io/github/actions/workflow/status/OWNER/REPO/ci.yml?style=flat-square&logo=github)](https://github.com/OWNER/REPO/actions/workflows/ci.yml)
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/OWNER/REPO/codeql.yml?style=flat-square&logo=github)](https://github.com/OWNER/REPO/actions/workflows/codeql.yml)
-[![Python](https://img.shields.io/badge/python-3.10%2B-blue?style=flat-square&logo=python)](#)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue?style=flat-square&logo=python)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green?style=flat-square)](LICENSE)
 <!-- [![PyPI](https://img.shields.io/pypi/v/cognitive-core-engine?style=flat-square&logo=pypi)](https://pypi.org/project/cognitive-core-engine/) -->
 <!-- [![Coverage](https://img.shields.io/badge/coverage-??%25-lightgrey?style=flat-square)](# "verification required") -->


### PR DESCRIPTION
## Summary
- link Python badge to official Python website

## Testing
- `ruff check README.md`
- `mypy .` *(fails: Duplicate module named "test_cli")*
- `pytest -q` *(skipped: fastapi[test] not installed)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c556f446788329892185015ce7f357