### PR TITLE
docs: update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/OWNER/REPO/codeql.yml?style=flat-square&logo=github)](https://github.com/OWNER/REPO/actions/workflows/codeql.yml)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue?style=flat-square&logo=python)](#)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green?style=flat-square)](LICENSE)
-<!-- [![PyPI](https://img.shields.io/pypi/v/cognitive-core-engine?style=flat-square&logo=pypi)](https://pypi.org/project/cognitive-core-engine/) -->
-<!-- [![Coverage](https://img.shields.io/badge/coverage-??%25-lightgrey?style=flat-square)](# "verification required") -->
+[![PyPI](https://img.shields.io/pypi/v/cognitive-core-engine?style=flat-square&logo=pypi)](https://pypi.org/project/cognitive-core-engine/)
 
 ## Зміст
 - [Огляд](#огляд)


### PR DESCRIPTION
## Summary
- show PyPI badge with package URL
- remove placeholder coverage badge

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install 'fastapi[test]'` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c556f5922c8329ab1d3ecb2a471f53