### PR TITLE
docs: remove inactive PyPI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/OWNER/REPO/codeql.yml?style=flat-square&logo=github)](https://github.com/OWNER/REPO/actions/workflows/codeql.yml)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue?style=flat-square&logo=python)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green?style=flat-square)](LICENSE)
-[![PyPI](https://img.shields.io/pypi/v/cognitive-core-engine?style=flat-square&logo=pypi)](https://pypi.org/project/cognitive-core-engine/)
 
 ## Зміст
 - [Огляд](#огляд)


### PR DESCRIPTION
## Summary
- drop PyPI badge from README since no package is published yet

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c5597a21408329b042f8edb3098a4d