### PR TITLE
docs: add API and CLI usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,29 @@ pytest
 ```
 
 ## API
+Докладніше див. [docs/API.md](docs/API.md).
+
+```bash
+# Перевірка стану сервісу
+curl http://localhost:8000/api/health
+
+# Обчислення скалярного добутку
+curl -X POST http://localhost:8000/api/dot \
+  -H "Content-Type: application/json" \
+  -d '{"a": [1, 2, 3], "b": [4, 5, 6]}'
+```
 
 ## CLI
+
+Ознайомтеся з [docs/OPERATIONS.md](docs/OPERATIONS.md) для деталей.
+
+```bash
+# Скалярний добуток векторами
+cogctl dotv 1,2,3 4,5,6
+
+# Розв'язання системи 2x2
+cogctl solve2x2 1 2 3 4 5 6
+```
 
 ## Тестування
 


### PR DESCRIPTION
## Summary
- document API usage with curl examples and link to docs
- document CLI usage with cogctl samples

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(fails: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c56586acf88329aa4fc7bce0d119af