### PR TITLE
feat: add pipeline executor and API

### DIFF
--- a/src/cognitive_core/api/main.py
+++ b/src/cognitive_core/api/main.py
@@ -1,13 +1,14 @@
 from fastapi import FastAPI
 
 from ..config.settings import Settings
-from .routers import events, health, math
+from .routers import events, health, math, pipelines
 
 settings = Settings()
 app = FastAPI(title=settings.app_name)
 app.include_router(health.router, prefix=settings.api_prefix, tags=["health"])
 app.include_router(math.router, prefix=settings.api_prefix, tags=["math"])
 app.include_router(events.router, prefix=settings.api_prefix, tags=["events"])
+app.include_router(pipelines.router, prefix=settings.api_prefix, tags=["pipelines"])
 
 
 @app.get("/")

--- a/src/cognitive_core/api/routers/pipelines.py
+++ b/src/cognitive_core/api/routers/pipelines.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from ...core.pipeline_executor import PipelineExecutor
+from ...domain.pipelines import Artifact, Pipeline
+
+router = APIRouter()
+
+
+# In-memory registry for demo purposes
+PIPELINES: dict[str, Pipeline] = {}
+
+
+def _sample_step() -> Artifact:
+    return Artifact(name="result", data=1)
+
+
+PIPELINES["sample"] = Pipeline(id="sample", name="Sample", steps=[_sample_step])
+executor = PipelineExecutor()
+
+
+class RunRequest(BaseModel):
+    pipeline_id: str
+
+
+@router.get("/v1/pipelines/{pipeline_id}")
+def get_pipeline(pipeline_id: str):
+    pipeline = PIPELINES.get(pipeline_id)
+    if not pipeline:
+        raise HTTPException(status_code=404, detail="Pipeline not found")
+    return {"id": pipeline.id, "name": pipeline.name, "steps": len(pipeline.steps)}
+
+
+@router.post("/v1/pipelines/run")
+def run_pipeline(req: RunRequest):
+    pipeline = PIPELINES.get(req.pipeline_id)
+    if not pipeline:
+        raise HTTPException(status_code=404, detail="Pipeline not found")
+    run = executor.execute(pipeline)
+    return {
+        "run_id": run.id,
+        "status": run.status,
+        "artifacts": [a.name for a in run.artifacts],
+    }

--- a/src/cognitive_core/core/pipeline_executor.py
+++ b/src/cognitive_core/core/pipeline_executor.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from time import time
+from uuid import uuid4
+
+from ..domain.pipelines import Artifact, Event, Pipeline, Run
+
+
+class PipelineExecutor:
+    """Executes pipelines synchronously."""
+
+    def execute(self, pipeline: Pipeline) -> Run:
+        run = Run(id=str(uuid4()), pipeline_id=pipeline.id, status="running")
+
+        for step in pipeline.steps:
+            step_name = getattr(step, "__name__", "step")
+            run.events.append(Event(step=step_name, type="start", timestamp=time()))
+            artifact = step()
+            if not isinstance(artifact, Artifact):
+                artifact = Artifact(name=step_name, data=artifact)
+            run.artifacts.append(artifact)
+            run.events.append(Event(step=step_name, type="end", timestamp=time()))
+
+        run.status = "completed"
+        return run

--- a/src/cognitive_core/domain/__init__.py
+++ b/src/cognitive_core/domain/__init__.py
@@ -1,0 +1,12 @@
+"""Domain models for cognitive core engine."""
+
+from .entities import Vector
+from .pipelines import Artifact, Event, Pipeline, Run
+
+__all__ = [
+    "Vector",
+    "Artifact",
+    "Event",
+    "Pipeline",
+    "Run",
+]

--- a/src/cognitive_core/domain/pipelines.py
+++ b/src/cognitive_core/domain/pipelines.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, List
+
+
+@dataclass(frozen=True)
+class Artifact:
+    """Materialized result produced by a pipeline step."""
+
+    name: str
+    data: Any
+
+
+@dataclass(frozen=True)
+class Event:
+    """Represents lifecycle events during a pipeline run."""
+
+    step: str
+    type: str
+    timestamp: float
+
+
+@dataclass
+class Run:
+    """Execution state of a pipeline."""
+
+    id: str
+    pipeline_id: str
+    status: str
+    events: List[Event] = field(default_factory=list)
+    artifacts: List[Artifact] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class Pipeline:
+    """A simple synchronous pipeline definition."""
+
+    id: str
+    name: str
+    steps: List[Callable[[], Artifact]]

--- a/tests/test_pipeline_executor.py
+++ b/tests/test_pipeline_executor.py
@@ -1,0 +1,16 @@
+def test_pipeline_executor_runs_steps():
+    from cognitive_core.core.pipeline_executor import PipelineExecutor
+    from cognitive_core.domain.pipelines import Artifact, Pipeline
+
+    def step_one():
+        return Artifact(name="a", data=1)
+
+    def step_two():
+        return Artifact(name="b", data=2)
+
+    pipeline = Pipeline(id="p1", name="Test", steps=[step_one, step_two])
+    run = PipelineExecutor().execute(pipeline)
+
+    assert [a.data for a in run.artifacts] == [1, 2]
+    assert run.status == "completed"
+    assert len(run.events) == 4

--- a/tests/test_pipelines_api.py
+++ b/tests/test_pipelines_api.py
@@ -1,0 +1,9 @@
+def test_get_pipeline(api_client):
+    assert api_client.get("/api/v1/pipelines/sample").json()["id"] == "sample"
+
+
+def test_run_pipeline(api_client):
+    resp = api_client.post("/api/v1/pipelines/run", json={"pipeline_id": "sample"})
+    data = resp.json()
+    assert data["status"] == "completed"
+    assert data["artifacts"] == ["result"]


### PR DESCRIPTION
## Summary
- add domain models for pipelines, runs, events and artifacts
- implement synchronous pipeline executor and API router
- test execution logic and pipeline endpoints

## Testing
- `pre-commit run --files src/cognitive_core/api/main.py src/cognitive_core/domain/__init__.py src/cognitive_core/api/routers/pipelines.py src/cognitive_core/core/pipeline_executor.py src/cognitive_core/domain/pipelines.py tests/test_pipeline_executor.py tests/test_pipelines_api.py` (fails: command not found)
- `pip install pre-commit` (fails: Could not find a version that satisfies the requirement pre-commit (proxy 403))
- `pip install fastapi` (fails: Could not find a version that satisfies the requirement fastapi (proxy 403))
- `pytest tests/test_pipeline_executor.py --noconftest`
- `pytest tests/test_pipelines_api.py` (fails: No module named 'fastapi')

------
https://chatgpt.com/codex/tasks/task_e_68c565879fe88329aee59c4e2a98b2f6