### PR TITLE
docs: refine architecture, operations, and API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ A --> P[Plugins]
 
 ## Документація
 
-Докладніше у [docs/](docs/).
+- [API](docs/api.md)
+- [Архітектура](docs/architecture.md)
+- [Операції](docs/operations.md)
 
 ## Спільнота
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,5 +1,0 @@
-# API
-- GET /api/health -> {"status":"ok"}
-- POST /api/dot -> {"result": float}
-- POST /api/solve2x2 -> {"x": float, "y": float}
-- GET /api/events/sse -> Server-Sent Events demo

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,0 @@
-# Architecture (Clean Architecture)
-
-Layers:
-- domain: entities/invariants
-- app: use-cases/services (pure logic)
-- api: FastAPI routers (health, math, sse)
-- plugins: registry + example
-- tests: unit + e2e

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,7 +1,0 @@
-# Operations
-
-## Local
-make setup && make api
-
-## Docker
-docker compose up -d --build

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,63 @@
+# API
+
+## GET /api/health
+Request:
+```http
+GET /api/health HTTP/1.1
+```
+Response:
+```json
+{
+  "status": "ok"
+}
+```
+
+## POST /api/dot
+Request:
+```http
+POST /api/dot HTTP/1.1
+Content-Type: application/json
+
+{
+  "a": [1, 2, 3],
+  "b": [4, 5, 6]
+}
+```
+Response:
+```json
+{
+  "result": 32.0
+}
+```
+
+## POST /api/solve2x2
+Request:
+```http
+POST /api/solve2x2 HTTP/1.1
+Content-Type: application/json
+
+{
+  "a": 1,
+  "b": 1,
+  "c": 1,
+  "d": -1,
+  "e": 1,
+  "f": 0
+}
+```
+Response:
+```json
+{
+  "x": 0.5,
+  "y": 0.5
+}
+```
+
+## GET /api/events/sse
+Server-Sent Events stream providing real-time messages.
+Response:
+```text
+data: hello
+
+data: world
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,39 @@
+# Architecture
+
+The engine follows the principles of Clean Architecture, separating domain logic from framework-specific concerns.
+
+```mermaid
+flowchart TD
+    subgraph Domain
+        D[Entities]
+    end
+    subgraph Application
+        U[Use Cases]
+    end
+    subgraph Interfaces
+        F[FastAPI]
+        C[CLI]
+        P[Plugins]
+    end
+    D --> U
+    U --> F
+    U --> C
+    U --> P
+```
+
+## Layers
+- **domain**: entities and invariants
+- **app**: use cases and services (pure logic)
+- **api**: FastAPI routers (health, math, sse)
+- **plugins**: registry and examples
+- **tests**: unit and end-to-end
+
+## Setup
+1. Install dependencies:
+   ```bash
+   make setup
+   ```
+2. Run the API server:
+   ```bash
+   make api
+   ```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,30 @@
+# Operations
+
+## Local
+```mermaid
+flowchart LR
+    Dev[Developer] -->|make setup| Env[Virtualenv]
+    Env -->|make api| App[FastAPI Server]
+```
+Steps:
+1. Install dependencies and start the API:
+   ```bash
+   make setup
+   make api
+   ```
+2. Open the docs at [http://localhost:8000/docs](http://localhost:8000/docs).
+
+## Docker
+```mermaid
+flowchart LR
+    Dev[Developer] -->|docker compose up -d --build| Container[API Container]
+```
+Steps:
+1. Build and run services:
+   ```bash
+   docker compose up -d --build
+   ```
+2. Follow logs:
+   ```bash
+   docker compose logs -f api
+   ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,1 +1,5 @@
-site_name: cognitive-core-engine\n
+site_name: cognitive-core-engine
+nav:
+  - API: api.md
+  - Architecture: architecture.md
+  - Operations: operations.md


### PR DESCRIPTION
## Summary
- rename docs to lowercase and expand API with request/response examples
- elaborate architecture and operations docs with mermaid diagrams and setup steps
- link docs from README and configure mkdocs navigation

## Testing
- `pytest` *(fails: fastapi[test] not installed; skipping API tests)*
- `mkdocs build` *(command not found: mkdocs)*
- `pre-commit run --files README.md mkdocs.yml docs/api.md docs/architecture.md docs/operations.md` *(command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68c56589c4a8832994827d63e674c964