### PR TITLE
docs: add pre-commit usage instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,18 @@
 # Contributing
 
 Use Conventional Commits. Run `make lint test` before PR.
+
+## Pre-commit
+
+Install and configure the pre-commit hooks:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Before committing, run the hooks against your changes:
+
+```bash
+pre-commit run --files <changed files>
+```


### PR DESCRIPTION
## Summary
- document installing and running pre-commit in contributing guide

## Testing
- `pre-commit run --files CONTRIBUTING.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `make lint test` *(fails: fastapi[test] not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5658abbe083298363a428cb631f96