### PR TITLE
Add property-based test for 2x2 solver

### DIFF
--- a/tests/property/test_solve2x2_property.py
+++ b/tests/property/test_solve2x2_property.py
@@ -1,0 +1,19 @@
+from hypothesis import assume, given, strategies as st
+import pytest
+
+from cognitive_core.core.math_utils import solve_2x2
+
+
+@given(
+    st.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False),
+    st.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False),
+    st.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False),
+    st.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False),
+    st.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False),
+    st.floats(-1e6, 1e6, allow_nan=False, allow_infinity=False),
+)
+def test_recomposition(a, b, c, d, e, f):
+    assume(abs(a * d - b * c) > 1e-6)
+    x, y = solve_2x2(a, b, c, d, e, f)
+    assert a * x + b * y == pytest.approx(e)
+    assert c * x + d * y == pytest.approx(f)


### PR DESCRIPTION
## Summary
- add Hypothesis property test ensuring `solve_2x2` recomposes the original system

## Testing
- `pip install 'fastapi[test]'` *(failed: Could not find a version that satisfies the requirement fastapi[test])*
- `pytest tests/property/test_solve2x2_property.py` *(failed: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5658b9eb083299a56b85dbff3a7b2