### PR TITLE
test: verify SSE tick events

### DIFF
--- a/tests/test_sse_api.py
+++ b/tests/test_sse_api.py
@@ -1,3 +1,28 @@
+import json
+import time
+
+
 def test_sse(api_client):
     r = api_client.get("/api/events/sse", stream=True)
     assert "text/event-stream" in r.headers.get("content-type", "")
+
+    steps = []
+    timestamps = []
+
+    for line in r.iter_lines():
+        if not line:
+            continue
+        if isinstance(line, bytes):
+            line = line.decode()
+        if line.startswith("data:"):
+            payload = json.loads(line.split(":", 1)[1].strip())
+            steps.append(payload["step"])
+            timestamps.append(time.monotonic())
+            if len(steps) == 5:
+                break
+
+    assert steps == [1, 2, 3, 4, 5]
+
+    intervals = [b - a for a, b in zip(timestamps, timestamps[1:])]
+    for interval in intervals:
+        assert 0.15 <= interval <= 0.3


### PR DESCRIPTION
## Summary
- extend SSE API test to read stream and assert five incremental tick events
- check timing between events to be roughly 0.2s

## Testing
- `pytest tests/test_sse_api.py::test_sse -q` *(fails: fastapi[test] not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5658d90bc832980594b5914c6d271