### PR TITLE
docs: add development setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,17 @@
 
 Use Conventional Commits. Run `make lint test` before PR.
 
-## Pre-commit
+## Development setup
 
-Install and configure the pre-commit hooks:
+Install FastAPI with its test dependencies and set up pre-commit hooks:
 
 ```bash
+pip install 'fastapi[test]'
 pip install pre-commit
 pre-commit install
 ```
+
+## Pre-commit
 
 Before committing, run the hooks against your changes:
 


### PR DESCRIPTION
## Summary
- document fastapi and pre-commit installation in new development setup section

## Testing
- `pip install 'fastapi[test]'` *(fails: Could not find a version that satisfies the requirement fastapi[test])* 
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pre-commit install` *(fails: command not found)*
- `pre-commit run --files CONTRIBUTING.md` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c56b03e7c88329bfbe0b363bc81a7b