### PR TITLE
fix: correct README code fences

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-````markdown
 # <img src="assets/logo.svg" alt="Логотип" width="48" align="left"/> cognitive-core-engine
 
 > Базовий рушій для когнітивних сервісів із API, CLI та підтримкою плагінів.
@@ -35,7 +34,7 @@
 ## Встановлення
 ```bash
 pip install -e '.[api,test,dev]'
-````
+```
 
 ## Швидкий старт
 


### PR DESCRIPTION
## Summary
- remove stray markdown fence
- normalize code fence closing in installation snippet

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi', skipped API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c56d7e878c8329a6380f944d3ac57c