### PR TITLE
docs: fix README links to API and operations docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pytest
 ```
 
 ## API
-Докладніше див. [docs/API.md](docs/API.md).
+Докладніше див. [docs/api.md](docs/api.md).
 
 ```bash
 # Перевірка стану сервісу
@@ -59,7 +59,7 @@ curl -X POST http://localhost:8000/api/dot \
 
 ## CLI
 
-Ознайомтеся з [docs/OPERATIONS.md](docs/OPERATIONS.md) для деталей.
+Ознайомтеся з [docs/operations.md](docs/operations.md) для деталей.
 
 ```bash
 # Скалярний добуток векторами


### PR DESCRIPTION
## Summary
- fix README references to lowercase API and operations docs

## Testing
- `make lint` *(fails: unrecognized subcommand '.'; bandit not found)*
- `make test` *(fails: fastapi[test] not installed)*
- `alembic upgrade head` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c56d812820832989e15e53c7fa9ec5