### PR TITLE
feat: add plugin loader and CLI management

### DIFF
--- a/src/cognitive_core/plugins/example/math_plugin.py
+++ b/src/cognitive_core/plugins/example/math_plugin.py
@@ -1,5 +1,5 @@
 from ...app.services import dot
-from .. import register
+from .. import PluginMetadata, register
 
 
 class MathPlugin:
@@ -11,4 +11,5 @@ class MathPlugin:
         return {"result": dot(a, b)}
 
 
-register(MathPlugin())
+metadata = PluginMetadata(name="math.dot", version="1.0.0", requirements=[])
+register(MathPlugin(), metadata)

--- a/src/cognitive_core/plugins/plugin_loader.py
+++ b/src/cognitive_core/plugins/plugin_loader.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+
+def load_plugins() -> None:
+    """Scan the plugins package and import all modules.
+
+    Importing modules causes them to register themselves with the plugin
+    registry via the ``register`` function.
+    """
+
+    base_dir = Path(__file__).resolve().parent
+    package = __name__.rsplit(".", 1)[0]
+
+    for path in base_dir.rglob("*.py"):
+        if path.name in {"__init__.py", "plugin_loader.py"}:
+            continue
+        rel = path.relative_to(base_dir).with_suffix("")
+        module_name = ".".join((package, *rel.parts))
+        importlib.import_module(module_name)

--- a/tests/test_plugins_registry.py
+++ b/tests/test_plugins_registry.py
@@ -1,9 +1,12 @@
 from cognitive_core.plugins import REGISTRY, dispatch
+from cognitive_core.plugins.plugin_loader import load_plugins
 
 
 def test_math_plugin_registration_and_execution():
-    import cognitive_core.plugins.example.math_plugin  # noqa: F401
+    load_plugins()
 
     assert "math.dot" in REGISTRY
+    meta, _ = REGISTRY["math.dot"]
+    assert meta.version == "1.0.0"
     result = dispatch("math.dot", {"a": [1, 2], "b": [3, 4]})
     assert result["result"] == 11


### PR DESCRIPTION
## Summary
- add plugin loader to scan and import available plugins
- attach metadata to plugins and expose through registry
- extend CLI with plugin list/install/remove commands

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install 'fastapi[test]'` *(fails: Could not find a version that satisfies the requirement fastapi[test])*
- `pytest tests/test_plugins_registry.py -q --noconftest`


------
https://chatgpt.com/codex/tasks/task_e_68c573454dcc8329a112fa6fc63ec9a0