### PR TITLE
Add pipeline benchmarks and CI caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,17 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/pyproject.toml') }}
           restore-keys: ${{ runner.os }}-pip-
+      - uses: actions/cache@v4
+        with:
+          path: .benchmarks
+          key: ${{ runner.os }}-benchmarks-${{ github.ref }}
+          restore-keys: ${{ runner.os }}-benchmarks-
       - name: Install dependencies
         run: |
           python -m pip install -U pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f pyproject.toml ]; then pip install .; fi
-          pip install ruff mypy bandit safety pytest coverage
+          pip install ruff mypy bandit safety pytest pytest-benchmark coverage
       - name: Ruff
         run: ruff --output-format=github .
       - name: Mypy
@@ -70,6 +75,10 @@ jobs:
         run: safety check --full-report --json > reports/safety.json || true
       - name: Pytest
         run: pytest --junitxml=reports/junit-python.xml --cov=. --cov-report=xml
+      - name: Benchmarks
+        run: |
+          mkdir -p reports
+          pytest tests/benchmarks --benchmark-save=bench --benchmark-json=reports/benchmarks.json
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -80,6 +89,7 @@ jobs:
             reports/junit-python.xml
             reports/bandit.xml
             reports/safety.json
+            reports/benchmarks.json
 
   node:
     needs: detect

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: setup lint test coverage security fmt api docs build docker dev
+.PHONY: setup lint test coverage security fmt api docs build docker dev bench
 
 setup:
 	@if [ -f requirements.txt ] || [ -f pyproject.toml ]; then \
@@ -31,6 +31,9 @@ test:
 	@if [ -f go.mod ]; then go test ./...; fi
 	@if [ -f Cargo.toml ]; then cargo test; fi
 	@if [ -f pom.xml ]; then mvn -B test; fi
+
+bench:
+	@if [ -f requirements.txt ] || [ -f pyproject.toml ]; then pytest tests/benchmarks --benchmark-save=bench --benchmark-json=benchmarks.json; fi
 
 coverage:
 	@if [ -f requirements.txt ] || [ -f pyproject.toml ]; then pytest --cov=. --cov-report=xml; fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,15 @@ dependencies = ["pydantic>=2.7", "typing-extensions>=4.8"]
 
 [project.optional-dependencies]
 api = ["fastapi>=0.111", "uvicorn>=0.29", "httpx>=0.25"]
-test = ["pytest>=7.4", "pytest-cov>=4.1", "httpx>=0.25", "hypothesis>=6.99", "pyyaml>=6.0.1"]
-dev = ["ruff>=0.5.0", "black>=24.4", "isort>=5.13", "mypy>=1.8", "types-requests"]
+test = [
+    "pytest>=7.4",
+    "pytest-cov>=4.1",
+    "httpx>=0.25",
+    "hypothesis>=6.99",
+    "pyyaml>=6.0.1",
+    "pytest-benchmark>=4.0",
+]
+dev = ["ruff>=0.5.0", "black>=24.4", "isort>=5.13", "mypy>=1.8", "types-requests", "pytest-benchmark>=4.0"]
 
 [project.scripts]
 cogctl = "cognitive_core.cli:main"

--- a/tests/benchmarks/test_pipeline_bench.py
+++ b/tests/benchmarks/test_pipeline_bench.py
@@ -1,0 +1,22 @@
+from cognitive_core.core.pipeline_executor import PipelineExecutor
+from cognitive_core.domain.pipelines import Artifact, Pipeline
+
+
+def test_pipeline_execution_benchmark(benchmark):
+    """Benchmark execution time of a simple pipeline."""
+
+    def step_sum() -> Artifact:
+        total = sum(range(1000))
+        return Artifact(name="sum", data=total)
+
+    def step_double() -> Artifact:
+        values = [x * 2 for x in range(1000)]
+        return Artifact(name="double", data=values)
+
+    pipeline = Pipeline(id="bench", name="Benchmark", steps=[step_sum, step_double])
+    executor = PipelineExecutor()
+
+    def run_pipeline() -> None:
+        executor.execute(pipeline)
+
+    benchmark(run_pipeline)


### PR DESCRIPTION
## Summary
- benchmark pipeline execution using pytest-benchmark
- add `bench` make target for running benchmarks
- cache benchmark results in CI for regression tracking

## Testing
- `pytest tests/benchmarks/test_pipeline_bench.py --confcutdir=tests/benchmarks -q` *(fails: fixture 'benchmark' not found)*
- `make bench` *(fails: fastapi[test] not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5734d284883299a76ff73989a0493