### PR TITLE
Document asset generation and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+assets/og-banner.png
+media/api-demo.gif
+media/cli-demo.gif

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-````markdown
 # <img src="assets/logo.svg" alt="Логотип" width="48" align="left"/> cognitive-core-engine
 
 > Базовий рушій для когнітивних сервісів із API, CLI та підтримкою плагінів.
@@ -7,6 +6,8 @@
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/neuron7x/cognitive-core-engine/codeql.yml?style=flat-square&logo=github)](https://github.com/neuron7x/cognitive-core-engine/actions/workflows/codeql.yml)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue?style=flat-square&logo=python)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green?style=flat-square)](LICENSE)
+
+
 
 ## Зміст
 - [Огляд](#огляд)
@@ -35,17 +36,19 @@
 ## Встановлення
 ```bash
 pip install -e '.[api,test,dev]'
-````
+```
 
 ## Швидкий старт
 
 ```bash
+python tools/gen_assets.py  # формує банер та демо-GIF
 cogctl --help
 pytest
 ```
 
 ## API
-Докладніше див. [docs/API.md](docs/API.md).
+Демо-GIF можна згенерувати через `tools/gen_assets.py`.
+Докладніше див. [docs/api.md](docs/api.md).
 
 ```bash
 # Перевірка стану сервісу
@@ -58,8 +61,8 @@ curl -X POST http://localhost:8000/api/dot \
 ```
 
 ## CLI
-
-Ознайомтеся з [docs/OPERATIONS.md](docs/OPERATIONS.md) для деталей.
+Демо-GIF для CLI також генерується скриптом.
+Ознайомтеся з [docs/operations.md](docs/operations.md) для деталей.
 
 ```bash
 # Скалярний добуток векторами

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,4 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect width="100" height="100" rx="15" fill="#3b82f6"/>
-  <text x="50" y="55" font-size="50" text-anchor="middle" fill="#ffffff" font-family="Arial, sans-serif">CC</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <circle cx="60" cy="60" r="55" fill="#3b82f6"/>
+  <line x1="40" y1="50" x2="80" y2="50" stroke="#ffffff" stroke-width="4"/>
+  <line x1="40" y1="50" x2="60" y2="80" stroke="#ffffff" stroke-width="4"/>
+  <line x1="80" y1="50" x2="60" y2="80" stroke="#ffffff" stroke-width="4"/>
+  <circle cx="40" cy="50" r="8" fill="#ffffff"/>
+  <circle cx="80" cy="50" r="8" fill="#ffffff"/>
+  <circle cx="60" cy="80" r="8" fill="#ffffff"/>
 </svg>

--- a/src/cognitive_core/api/main.py
+++ b/src/cognitive_core/api/main.py
@@ -14,4 +14,5 @@ app.include_router(pipelines.router, prefix=settings.api_prefix, tags=["pipeline
 
 @app.get("/")
 def root():
+    """Return basic application information."""
     return {"name": settings.app_name}

--- a/tests/tools/test_gen_assets.py
+++ b/tests/tools/test_gen_assets.py
@@ -1,0 +1,30 @@
+"""Tests for tools.gen_assets."""
+
+import struct
+
+from tools.gen_assets import generate_banner, generate_gifs
+
+
+def test_generate_banner(tmp_path):
+    out = tmp_path / "banner.png"
+    generate_banner(out)
+    assert out.exists()
+    with out.open("rb") as f:
+        assert f.read(8) == b"\x89PNG\r\n\x1a\n"
+
+
+def _gif_size(path):
+    with open(path, "rb") as f:
+        header = f.read(10)
+    assert header[:6] == b"GIF89a"
+    return struct.unpack("<HH", header[6:10])
+
+
+def test_generate_gifs(tmp_path):
+    generate_gifs(tmp_path)
+    api = tmp_path / "api-demo.gif"
+    cli = tmp_path / "cli-demo.gif"
+    assert api.exists() and cli.exists()
+    assert _gif_size(api) == (132, 24)
+    assert _gif_size(cli) == (132, 24)
+

--- a/tools/gen_assets.py
+++ b/tools/gen_assets.py
@@ -1,0 +1,369 @@
+import struct, zlib, math, os
+
+# Utility functions for PNG
+
+def png_chunk(tag, data):
+    return (struct.pack('!I', len(data)) + tag + data +
+            struct.pack('!I', zlib.crc32(tag + data) & 0xffffffff))
+
+def save_png(path, width, height, get_pixel):
+    """Save a minimal RGB PNG image.
+
+    Args:
+        path: Destination file path.
+        width: Image width in pixels.
+        height: Image height in pixels.
+        get_pixel: Callable returning ``(r, g, b)`` for coordinates ``x, y``.
+    """
+    rows = []
+    for y in range(height):
+        row = bytearray()
+        row.append(0)  # filter type 0
+        for x in range(width):
+            r, g, b = get_pixel(x, y)
+            row.extend([r, g, b])
+        rows.append(bytes(row))
+    raw = b''.join(rows)
+    ihdr = struct.pack('!IIBBBBB', width, height, 8, 2, 0, 0, 0)
+    idat = zlib.compress(raw, 9)
+    with open(path, 'wb') as f:
+        f.write(b'\x89PNG\r\n\x1a\n')
+        f.write(png_chunk(b'IHDR', ihdr))
+        f.write(png_chunk(b'IDAT', idat))
+        f.write(png_chunk(b'IEND', b''))
+
+# Draw og-banner
+
+def banner_pixel(x, y):
+    # simple horizontal gradient
+    start = (30, 64, 175)
+    end = (59, 130, 246)
+    t = x / 1279
+    r = int(start[0] + (end[0] - start[0]) * t)
+    g = int(start[1] + (end[1] - start[1]) * t)
+    b = int(start[2] + (end[2] - start[2]) * t)
+    return r, g, b
+
+# After saving base gradient, overlay simple network logo
+
+def generate_banner(path):
+    """Render the Open Graph banner to ``path``."""
+    width, height = 1280, 640
+    # create base image array
+    pixels = [bytearray([0,0,0]*width) for _ in range(height)]
+    for y in range(height):
+        t = y  # vertical component not used
+        for x in range(width):
+            r,g,b = banner_pixel(x,y)
+            idx = x*3
+            pixels[y][idx:idx+3] = bytes([r,g,b])
+    # draw logo: three nodes connected
+    def set_pixel(x,y,r,g,b):
+        if 0 <= x < width and 0 <= y < height:
+            idx = x*3
+            pixels[y][idx:idx+3] = bytes([r,g,b])
+    def draw_circle(cx,cy,rad,color):
+        for y in range(cy-rad, cy+rad+1):
+            for x in range(cx-rad, cx+rad+1):
+                if (x-cx)**2 + (y-cy)**2 <= rad*rad:
+                    set_pixel(x,y,*color)
+    def draw_line(x0,y0,x1,y1,th,color):
+        dx=x1-x0; dy=y1-y0
+        length=int(math.hypot(dx,dy))
+        for i in range(length+1):
+            t=i/length
+            x=int(x0+dx*t)
+            y=int(y0+dy*t)
+            for yy in range(y-th//2, y+th//2+1):
+                for xx in range(x-th//2, x+th//2+1):
+                    set_pixel(xx,yy,*color)
+    # positions
+    nodes=[(540,320),(640,250),(740,320)]
+    # lines
+    draw_line(*nodes[0],*nodes[1],12,(255,255,255))
+    draw_line(*nodes[1],*nodes[2],12,(255,255,255))
+    draw_line(*nodes[0],*nodes[2],12,(255,255,255))
+    for cx,cy in nodes:
+        draw_circle(cx,cy,40,(255,255,255))
+    # write image
+    def get_pixel(x,y):
+        idx=x*3
+        row=pixels[y]
+        return row[idx],row[idx+1],row[idx+2]
+    save_png(path,width,height,get_pixel)
+
+# Minimal font for GIF
+FONT = {
+    'A':[
+        '010',
+        '101',
+        '111',
+        '101',
+        '101',
+    ],
+    'C':[
+        '011',
+        '100',
+        '100',
+        '100',
+        '011',
+    ],
+    'D':[
+        '110',
+        '101',
+        '101',
+        '101',
+        '110',
+    ],
+    'E':[
+        '111',
+        '100',
+        '110',
+        '100',
+        '111',
+    ],
+    'G':[
+        '011',
+        '100',
+        '101',
+        '101',
+        '011',
+    ],
+    'I':[
+        '111',
+        '010',
+        '010',
+        '010',
+        '111',
+    ],
+    'L':[
+        '100',
+        '100',
+        '100',
+        '100',
+        '111',
+    ],
+    'M':[
+        '101',
+        '111',
+        '101',
+        '101',
+        '101',
+    ],
+    'N':[
+        '101',
+        '111',
+        '111',
+        '111',
+        '101',
+    ],
+    'O':[
+        '010',
+        '101',
+        '101',
+        '101',
+        '010',
+    ],
+    'P':[
+        '110',
+        '101',
+        '110',
+        '100',
+        '100',
+    ],
+    'R':[
+        '110',
+        '101',
+        '110',
+        '101',
+        '101',
+    ],
+    'U':[
+        '101',
+        '101',
+        '101',
+        '101',
+        '111',
+    ],
+    ' ': [
+        '000',
+        '000',
+        '000',
+        '000',
+        '000',
+    ],
+}
+
+FONT['T'] = [
+    '111',
+    '010',
+    '010',
+    '010',
+    '010',
+]
+FONT['V'] = [
+    '101',
+    '101',
+    '101',
+    '101',
+    '010',
+]
+
+# draw text using font
+
+def render_text(text, scale=4, padding=2):
+    """Convert text into a 1-bit pixel matrix using ``FONT``.
+
+    Args:
+        text: Message to render (supports ``\n`` for multiple lines).
+        scale: Pixel scaling factor.
+        padding: Padding around the rendered text.
+
+    Returns:
+        List of lists representing the monochrome image (0=black, 1=white).
+    """
+    lines = text.split('\n')
+    width = max(len(line) for line in lines)*(3+1)*scale + padding*2
+    height = len(lines)*5*scale + padding*2
+    canvas = [[1]*width for _ in range(height)]  # 1=white, 0=black
+    for li, line in enumerate(lines):
+        y0 = padding + li*5*scale
+        x0 = padding
+        for ch in line:
+            glyph = FONT.get(ch.upper(), FONT[' '])
+            for gy,row in enumerate(glyph):
+                for gx,val in enumerate(row):
+                    if val=='1':
+                        for ys in range(scale):
+                            for xs in range(scale):
+                                canvas[y0+gy*scale+ys][x0+gx*scale+xs] = 0
+            x0 += (3+1)*scale
+    return canvas
+
+# LZW encoding
+
+def lzw_compress(data, min_code_size):
+    clear = 1 << min_code_size
+    end = clear + 1
+    dict_size = end + 1
+    dictionary = {bytes([i]): i for i in range(clear)}
+    w = b''
+    result = [clear]
+    for k in data:
+        kbytes = bytes([k])
+        wk = w + kbytes
+        if wk in dictionary:
+            w = wk
+        else:
+            result.append(dictionary[w])
+            dictionary[wk] = dict_size
+            dict_size += 1
+            w = kbytes
+            if dict_size >= 4095:
+                result.append(clear)
+                dictionary = {bytes([i]): i for i in range(clear)}
+                dict_size = end + 1
+    if w:
+        result.append(dictionary[w])
+    result.append(end)
+    # pack bits
+    size = min_code_size + 1
+    data_out = []
+    cur = 0
+    bits = 0
+    for code in result:
+        cur |= code << bits
+        bits += size
+        while bits >= 8:
+            data_out.append(cur & 0xFF)
+            cur >>= 8
+            bits -= 8
+        if dict_size == (1 << size) and size < 12:
+            size += 1
+    if bits:
+        data_out.append(cur)
+    return bytes(data_out)
+
+
+def gif_frame(pixels, delay):
+    """Encode a single GIF frame.
+
+    Args:
+        pixels: 2D list of palette indices.
+        delay: Frame delay in hundredths of a second.
+
+    Returns:
+        Bytes representing the encoded frame.
+    """
+    height = len(pixels)
+    width = len(pixels[0])
+    flat = bytes([p for row in pixels for p in row])
+    min_code_size = 2
+    compressed = lzw_compress(flat, min_code_size)
+    def subblocks(data):
+        out = bytearray()
+        for i in range(0,len(data),255):
+            chunk = data[i:i+255]
+            out.append(len(chunk))
+            out.extend(chunk)
+        out.append(0)
+        return bytes(out)
+    frame = bytearray()
+    frame.extend(b'\x21\xF9\x04\x08')
+    frame.extend(struct.pack('<H', delay))
+    frame.append(0)
+    frame.append(0)
+    frame.extend(b'\x2C')
+    frame.extend(struct.pack('<HHHH',0,0,width,height))
+    frame.append(0)
+    frame.append(min_code_size)
+    frame.extend(subblocks(compressed))
+    return bytes(frame)
+
+
+def save_gif(path, frames, delay):
+    """Save GIF animation from frames.
+
+    Args:
+        path: Destination file path.
+        frames: Sequence of pixel matrices.
+        delay: Frame delay in hundredths of a second.
+    """
+    height = len(frames[0])
+    width = len(frames[0][0])
+    with open(path,'wb') as f:
+        f.write(b'GIF89a')
+        f.write(struct.pack('<HH', width, height))
+        f.write(b'\x80\x00\x00')
+        f.write(b'\xff\xff\xff\x00\x00\x00')
+        f.write(b'\x21\xFF\x0BNETSCAPE2.0\x03\x01\x00\x00\x00')
+        for pixels in frames:
+            f.write(gif_frame(pixels, delay))
+        f.write(b';')
+
+
+def generate_gifs(out_dir):
+    """Generate demonstration GIFs into ``out_dir``.
+
+    Args:
+        out_dir: Directory path where GIF files will be written.
+    """
+    api_frames = [
+        render_text('API DEMO'),
+        render_text('CALLING'),
+        render_text('DONE'),
+    ]
+    cli_frames = [
+        render_text('CLI DEMO'),
+        render_text('RUN CMD'),
+        render_text('DONE'),
+    ]
+    # delay 40 * 3 =120? actual delay in hundredths of a second
+    save_gif(os.path.join(out_dir, 'api-demo.gif'), api_frames, 400)  # 4s each -> 12s
+    save_gif(os.path.join(out_dir, 'cli-demo.gif'), cli_frames, 400)
+
+if __name__ == '__main__':
+    os.makedirs('assets', exist_ok=True)
+    os.makedirs('media', exist_ok=True)
+    generate_banner('assets/og-banner.png')
+    generate_gifs('media')


### PR DESCRIPTION
## Summary
- remove committed banner and demo GIFs; document local generation workflow
- clean asset generator font mapping and add docstrings
- add tests for banner/GIF generation and ignore their outputs

## Testing
- `pip install -e '.[test,api]'` *(fails: Could not find a version that satisfies the requirement setuptools>=68)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68c56b03016883298461bc187af28d95