### PR TITLE
Add asynchronous pipeline executor

### DIFF
--- a/src/cognitive_core/core/pipeline_executor_async.py
+++ b/src/cognitive_core/core/pipeline_executor_async.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import inspect
+from time import time
+from uuid import uuid4
+
+from ..domain.pipelines import Artifact, Event, Pipeline, Run
+
+
+class PipelineExecutorAsync:
+    """Executes pipeline steps sequentially, awaiting coroutine steps."""
+
+    async def execute(self, pipeline: Pipeline) -> Run:
+        run = Run(id=str(uuid4()), pipeline_id=pipeline.id, status="running")
+
+        for step in pipeline.steps:
+            step_name = getattr(step, "__name__", "step")
+            run.events.append(Event(step=step_name, type="start", timestamp=time()))
+
+            result = step()
+            if inspect.isawaitable(result):
+                result = await result
+            if not isinstance(result, Artifact):
+                result = Artifact(name=step_name, data=result)
+            run.artifacts.append(result)
+
+            run.events.append(Event(step=step_name, type="end", timestamp=time()))
+
+        run.status = "completed"
+        return run

--- a/tests/unit/test_pipeline_executor_async.py
+++ b/tests/unit/test_pipeline_executor_async.py
@@ -1,0 +1,25 @@
+import asyncio
+
+from cognitive_core.core.pipeline_executor_async import PipelineExecutorAsync
+from cognitive_core.domain.pipelines import Pipeline
+
+
+def test_execute_awaits_coroutine_steps():
+    order = []
+
+    async def step_one():
+        await asyncio.sleep(0.01)
+        order.append("step_one")
+        return "a"
+
+    def step_two():
+        order.append("step_two")
+        return "b"
+
+    pipeline = Pipeline(id="p_async", name="AsyncPipe", steps=[step_one, step_two])
+    run = asyncio.run(PipelineExecutorAsync().execute(pipeline))
+
+    assert order == ["step_one", "step_two"]
+    assert [a.data for a in run.artifacts] == ["a", "b"]
+    assert run.status == "completed"
+    assert len(run.events) == 4


### PR DESCRIPTION
## Summary
- add `PipelineExecutorAsync` to sequentially await pipeline steps
- cover async executor with unit test

## Testing
- `ruff check src/cognitive_core/core/pipeline_executor_async.py tests/unit/test_pipeline_executor_async.py`
- `mypy src/cognitive_core/core/pipeline_executor_async.py tests/unit/test_pipeline_executor_async.py`
- `pytest tests/unit/test_pipeline_executor_async.py --confcutdir=tests/unit`


------
https://chatgpt.com/codex/tasks/task_e_68c57942e86083298a7c183ce61ec96a