### PR TITLE
Add basic CLI and API tests and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ cogctl solve2x2 1 2 3 4 5 6
 
 ```bash
 pytest
+
+# запуск лише CLI та API тестів
+pytest tests/cli/test_cli.py tests/api/test_root.py
 ```
 
 ## Architecture Overview / Огляд архітектури

--- a/tests/api/test_root.py
+++ b/tests/api/test_root.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from cognitive_core.api.main import app
+
+client = TestClient(app)
+
+
+def test_root_endpoint():
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "name" in r.json()
+
+
+def test_health_endpoint():
+    r = client.get("/api/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,0 +1,29 @@
+import shlex
+import subprocess
+
+import pytest
+
+
+def _run(cmd: str):
+    proc = subprocess.run(shlex.split(cmd), capture_output=True, text=True)
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+@pytest.mark.integration
+def test_cli_ping():
+    for exe in ("cogctl", "python -m cognitive_core.cli"):
+        rc, out, _ = _run(f"{exe} ping")
+        if rc == 0 and out:
+            assert out.strip() == "pong"
+            return
+    pytest.skip("CLI ping not available")
+
+
+@pytest.mark.integration
+def test_cli_dotv():
+    for exe in ("cogctl", "python -m cognitive_core.cli"):
+        rc, out, _ = _run(f"{exe} dotv 1,2,3 4,5,6")
+        if rc == 0 and out:
+            assert '"dot": 32.0' in out
+            return
+    pytest.skip("CLI dotv not available")


### PR DESCRIPTION
## Summary
- add CLI integration tests for `cogctl ping` and `cogctl dotv`
- add FastAPI tests for `/` and `/api/health`
- document how to run these tests in README

## Testing
- `pre-commit run --files tests/cli/test_cli.py tests/api/test_root.py README.md` *(fails: pre-commit not installed)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pip install 'fastapi[test]'` *(fails: Could not find a version that satisfies the requirement fastapi[test])* 
- `pytest tests/cli/test_cli.py tests/api/test_root.py -q` *(fails: fastapi[test] not installed; skipping API tests)*
- `pytest tests/cli/test_cli.py --confcutdir=tests/cli -q`


------
https://chatgpt.com/codex/tasks/task_e_68c57944d6048329aeb7ca55543c644f