### PR TITLE
docs: expand asset generation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ pytest
 python tools/gen_assets.py
 ```
 
-Скрипт створює допоміжні графічні файли у каталозі `assets`, зокрема `logo.svg` та `og-banner.png`.
+Скрипт [tools/gen_assets.py](tools/gen_assets.py) створює допоміжні графічні файли у каталогах `assets` та `media`, зокрема:
+
+- `assets/logo.svg`
+- `assets/og-banner.png`
+- `media/api-demo.gif`
+- `media/cli-demo.gif`
 
 ## API
 Докладніше див. [docs/api.md](docs/api.md).


### PR DESCRIPTION
## Summary
- detail generated assets including GIF demos

## Testing
- `git fetch origin` (fails: "fatal: 'origin' does not appear to be a git repository")
- `git merge origin/main` (fails: "merge: origin/main - not something we can merge")
- `markdownlint README.md` (fails: command not found)
- `npx markdown-link-check README.md` (fails: 403 Forbidden)
- `pytest -q` (fails: ModuleNotFoundError: No module named 'fastapi')

------
https://chatgpt.com/codex/tasks/task_e_68c581b10b748329a0b47f77aa82064c