### PR TITLE
feat: add optional API key auth

### DIFF
--- a/src/cognitive_core/api/auth.py
+++ b/src/cognitive_core/api/auth.py
@@ -1,0 +1,22 @@
+"""Authentication helpers for API endpoints."""
+
+from fastapi import Security, HTTPException, status
+from fastapi.security import APIKeyHeader
+
+from ..config import settings
+
+# Header name that clients must supply API keys in.
+api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+async def verify_api_key(api_key: str | None = Security(api_key_header)) -> None:
+    """Validate the provided API key against configured settings.
+
+    If ``settings.api_key`` is not configured, authentication is effectively
+    disabled and all requests are allowed.  When configured, requests must
+    include the correct key in the ``X-API-Key`` header or a ``403`` is raised.
+    """
+    if not settings.api_key:
+        return
+    if api_key != settings.api_key:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid API key")

--- a/src/cognitive_core/api/main.py
+++ b/src/cognitive_core/api/main.py
@@ -1,8 +1,9 @@
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.responses import Response
 
-from ..config.settings import Settings
+from ..config import settings
 from ..utils.telemetry import setup_telemetry
+from .auth import verify_api_key
 try:  # pragma: no cover - allow running without prometheus-client installed
     from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 except Exception:  # pragma: no cover - fallback
@@ -11,9 +12,8 @@ except Exception:  # pragma: no cover - fallback
         return b""
 from .routers import events, health, math, pipelines
 
-settings = Settings()
 setup_telemetry(settings.app_name)
-app = FastAPI(title=settings.app_name)
+app = FastAPI(title=settings.app_name, dependencies=[Depends(verify_api_key)])
 # Register application routers
 app.include_router(health.router, prefix=settings.api_prefix, tags=["health"])
 app.include_router(math.router, prefix=settings.api_prefix, tags=["math"])

--- a/src/cognitive_core/api/routers/health.py
+++ b/src/cognitive_core/api/routers/health.py
@@ -6,10 +6,9 @@ from fastapi import APIRouter
 
 from ...utils.telemetry import instrument_route
 
-from ...config.settings import Settings
+from ...config import settings
 
 router = APIRouter()
-settings = Settings()
 
 
 @router.get("/health")

--- a/src/cognitive_core/config/__init__.py
+++ b/src/cognitive_core/config/__init__.py
@@ -1,0 +1,10 @@
+"""Application configuration objects."""
+
+from .settings import Settings
+
+# Instantiate a single settings object that can be shared across the
+# application.  Individual modules can import `settings` to access
+# configuration values without repeatedly instantiating `Settings()`.
+settings = Settings()
+
+__all__ = ["Settings", "settings"]

--- a/src/cognitive_core/config/settings.py
+++ b/src/cognitive_core/config/settings.py
@@ -5,5 +5,6 @@ class Settings(BaseSettings):
     app_name: str = "Cognitive Core Engine"
     api_prefix: str = "/api"
     debug: bool = False
+    api_key: str | None = None
 
     model_config = SettingsConfigDict(env_file=".env", env_prefix="COG_")

--- a/tests/security/test_api_key_auth.py
+++ b/tests/security/test_api_key_auth.py
@@ -1,0 +1,16 @@
+import pytest
+
+from cognitive_core.api import auth
+
+
+@pytest.mark.integration
+def test_api_key_enforced(api_client):
+    original = auth.settings.api_key
+    auth.settings.api_key = "secret"
+    try:
+        r = api_client.get("/api/health")
+        assert r.status_code == 403
+        r2 = api_client.get("/api/health", headers={"X-API-Key": "secret"})
+        assert r2.status_code == 200
+    finally:
+        auth.settings.api_key = original


### PR DESCRIPTION
## Summary
- add API key configuration and verification middleware
- centralize Settings object for reuse
- cover API key behaviour with integration test

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install 'fastapi[all]'` *(fails: Could not connect to proxy: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ae9c74d48329b65923184fefa535