### PR TITLE
Require API key unless explicitly disabled

### DIFF
--- a/src/cognitive_core/api/auth.py
+++ b/src/cognitive_core/api/auth.py
@@ -12,11 +12,12 @@ api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 async def verify_api_key(api_key: str | None = Security(api_key_header)) -> None:
     """Validate the provided API key against configured settings.
 
-    If ``settings.api_key`` is not configured, authentication is effectively
-    disabled and all requests are allowed.  When configured, requests must
-    include the correct key in the ``X-API-Key`` header or a ``403`` is raised.
+    If ``settings.api_key`` is ``None``, authentication is effectively
+    disabled and all requests are allowed. When configured (including an empty
+    string), requests must include the correct key in the ``X-API-Key`` header
+    or a ``403`` is raised.
     """
-    if not settings.api_key:
+    if settings.api_key is None:
         return
     if api_key != settings.api_key:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid API key")

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+
+from cognitive_core.api.main import app
+from cognitive_core.config import settings
+
+
+client = TestClient(app)
+
+
+def test_no_auth_when_api_key_none(monkeypatch):
+    monkeypatch.setattr(settings, "api_key", None)
+    r = client.get("/api/health")
+    assert r.status_code == 200
+
+
+def test_requires_auth_when_api_key_empty(monkeypatch):
+    monkeypatch.setattr(settings, "api_key", "")
+    r = client.get("/api/health")
+    assert r.status_code == 403
+    r = client.get("/api/health", headers={"X-API-Key": ""})
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary
- treat API key as disabled only when configuration value is `None`
- add tests verifying empty API key still requires authentication

## Testing
- `pip install fastapi[test]` *(failed: No matching distribution found)*
- `pytest tests/api/test_auth.py` *(failed: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c5b05277088329be5fbe36a436ff4d