### PR TITLE
test: access health without api key

### DIFF
--- a/tests/security/test_api_key_optional.py
+++ b/tests/security/test_api_key_optional.py
@@ -1,0 +1,10 @@
+import pytest
+
+from cognitive_core.api import auth
+
+
+@pytest.mark.integration
+def test_health_without_api_key(api_client, monkeypatch):
+    monkeypatch.setattr(auth.settings, "api_key", None)
+    response = api_client.get("/api/health")
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add integration test ensuring health endpoint works without API key when settings.api_key unset

## Testing
- `pre-commit run --files tests/security/test_api_key_optional.py` *(fails: command not found)*
- `pytest -q tests/security/test_api_key_optional.py` *(fails: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b052f4088329bb0b42cd14815eb7