### PR TITLE
refactor: set API key via monkeypatch

### DIFF
--- a/tests/security/test_api_key_auth.py
+++ b/tests/security/test_api_key_auth.py
@@ -1,16 +1,16 @@
 import pytest
 
 from cognitive_core.api import auth
+from cognitive_core.config import Settings
 
 
 @pytest.mark.integration
-def test_api_key_enforced(api_client):
-    original = auth.settings.api_key
-    auth.settings.api_key = "secret"
-    try:
-        r = api_client.get("/api/health")
-        assert r.status_code == 403
-        r2 = api_client.get("/api/health", headers={"X-API-Key": "secret"})
-        assert r2.status_code == 200
-    finally:
-        auth.settings.api_key = original
+def test_api_key_enforced(api_client, monkeypatch):
+    monkeypatch.setenv("COG_API_KEY", "secret")
+    monkeypatch.setattr(auth, "settings", Settings())
+
+    r = api_client.get("/api/health")
+    assert r.status_code == 403
+
+    r2 = api_client.get("/api/health", headers={"X-API-Key": "secret"})
+    assert r2.status_code == 200


### PR DESCRIPTION
## Summary
- refactor API key auth test to use monkeypatch.setenv and Settings()

## Testing
- `pytest tests/security/test_api_key_auth.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi'; tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b053947883298d89cc8bfd38dc0b