### PR TITLE
chore: add newline at end of config module

### DIFF
--- a/src/cognitive_core/config/__init__.py
+++ b/src/cognitive_core/config/__init__.py
@@ -8,3 +8,4 @@ from .settings import Settings
 settings = Settings()
 
 __all__ = ["Settings", "settings"]
+


### PR DESCRIPTION
## Summary
- ensure `src/cognitive_core/config/__init__.py` ends with a newline

## Testing
- `pytest` *(fails: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b36ce86c83299fcc2fec42137047