### PR TITLE
Ensure empty API key still requires header

### DIFF
--- a/src/cognitive_core/api/auth.py
+++ b/src/cognitive_core/api/auth.py
@@ -12,12 +12,13 @@ api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 async def verify_api_key(api_key: str | None = Security(api_key_header)) -> None:
     """Validate the provided API key against configured settings.
 
-    If ``settings.api_key`` is ``None``, authentication is effectively
-    disabled and all requests are allowed. When configured (including an empty
-    string), requests must include the correct key in the ``X-API-Key`` header
-    or a ``403`` is raised.
+    Authentication is disabled when ``settings.api_key`` is ``None`` so all
+    requests are allowed. When configured (including an empty string), requests
+    must include the correct key in the ``X-API-Key`` header or a ``403`` is
+    raised.
     """
     if settings.api_key is None:
         return
+
     if api_key != settings.api_key:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid API key")

--- a/tests/security/test_api_key_auth.py
+++ b/tests/security/test_api_key_auth.py
@@ -14,3 +14,15 @@ def test_api_key_enforced(api_client, monkeypatch):
 
     r2 = api_client.get("/api/health", headers={"X-API-Key": "secret"})
     assert r2.status_code == 200
+
+
+@pytest.mark.integration
+def test_empty_api_key_requires_header(api_client, monkeypatch):
+    monkeypatch.setenv("COG_API_KEY", "")
+    monkeypatch.setattr(auth, "settings", Settings())
+
+    r = api_client.get("/api/health")
+    assert r.status_code == 403
+
+    r2 = api_client.get("/api/health", headers={"X-API-Key": ""})
+    assert r2.status_code == 200


### PR DESCRIPTION
## Summary
- clarify API key authentication to only bypass checks when configured API key is `None`
- add integration test verifying that an empty API key still requires the `X-API-Key` header

## Testing
- `pytest tests/api/test_auth.py tests/security/test_api_key_auth.py` *(fails: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b36c59748329b397423a75767a92