### PR TITLE
test: health endpoint without API key

### DIFF
--- a/tests/security/test_health_no_header_without_key.py
+++ b/tests/security/test_health_no_header_without_key.py
@@ -1,0 +1,12 @@
+import pytest
+
+from cognitive_core.api import auth
+from cognitive_core.config import Settings
+
+
+@pytest.mark.integration
+def test_health_without_api_key_header(api_client, monkeypatch):
+    monkeypatch.delenv("COG_API_KEY", raising=False)
+    monkeypatch.setattr(auth, "settings", Settings())
+    response = api_client.get("/api/health")
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- test health endpoint succeeds without API key header when API key env is unset

## Testing
- `pytest tests/security/test_health_no_header_without_key.py -q` *(fails: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b36ca3448329930f00376bba6a73