### PR TITLE
test: use env var for api key

### DIFF
--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,20 +1,23 @@
 from fastapi.testclient import TestClient
 
 from cognitive_core.api.main import app
-from cognitive_core.config import settings
+from cognitive_core.api import auth
+from cognitive_core.config import Settings
 
 
 client = TestClient(app)
 
 
 def test_no_auth_when_api_key_none(monkeypatch):
-    monkeypatch.setattr(settings, "api_key", None)
+    monkeypatch.delenv("COG_API_KEY", raising=False)
+    monkeypatch.setattr(auth, "settings", Settings())
     r = client.get("/api/health")
     assert r.status_code == 200
 
 
 def test_requires_auth_when_api_key_empty(monkeypatch):
-    monkeypatch.setattr(settings, "api_key", "")
+    monkeypatch.setenv("COG_API_KEY", "")
+    monkeypatch.setattr(auth, "settings", Settings())
     r = client.get("/api/health")
     assert r.status_code == 403
     r = client.get("/api/health", headers={"X-API-Key": ""})

--- a/tests/security/test_api_key_optional.py
+++ b/tests/security/test_api_key_optional.py
@@ -1,10 +1,12 @@
 import pytest
 
 from cognitive_core.api import auth
+from cognitive_core.config import Settings
 
 
 @pytest.mark.integration
 def test_health_without_api_key(api_client, monkeypatch):
-    monkeypatch.setattr(auth.settings, "api_key", None)
+    monkeypatch.delenv("COG_API_KEY", raising=False)
+    monkeypatch.setattr(auth, "settings", Settings())
     response = api_client.get("/api/health")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- test API auth behavior using monkeypatched `COG_API_KEY`
- reload settings after env changes and remove direct `settings.api_key` mutations

## Testing
- `pytest tests/api/test_auth.py tests/security/test_api_key_optional.py tests/security/test_api_key_auth.py -q` *(fails: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b36d4e108329b22378eec6388dd7