### PR TITLE
chore: add newline after all declaration

### DIFF
--- a/src/cognitive_core/config/__init__.py
+++ b/src/cognitive_core/config/__init__.py
@@ -8,3 +8,4 @@ from .settings import Settings
 settings = Settings()
 
 __all__ = ["Settings", "settings"]
+


### PR DESCRIPTION
## Summary
- add missing trailing newline to `src/cognitive_core/config/__init__.py`

## Testing
- `pre-commit run --files src/cognitive_core/config/__init__.py` *(fails: pre-commit not installed)*
- `pytest` *(fails: fastapi not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b4cc5ca483298f85fe212338bfc0