### PR TITLE
Add tests for API key access scenarios

### DIFF
--- a/tests/security/test_api_key_access.py
+++ b/tests/security/test_api_key_access.py
@@ -1,0 +1,25 @@
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("pydantic_settings")
+
+from cognitive_core.api import auth
+from cognitive_core.config import Settings
+
+
+@pytest.mark.integration
+def test_health_without_api_key_unset(api_client, monkeypatch):
+    monkeypatch.delenv("COG_API_KEY", raising=False)
+    monkeypatch.setattr(auth, "settings", Settings())
+
+    response = api_client.get("/api/health")
+    assert response.status_code == 200
+
+
+@pytest.mark.integration
+def test_health_with_empty_api_key(api_client, monkeypatch):
+    monkeypatch.setenv("COG_API_KEY", "")
+    monkeypatch.setattr(auth, "settings", Settings())
+
+    response = api_client.get("/api/health")
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- add integration tests for API key behavior when unset or empty

## Testing
- `pytest tests/security/test_api_key_access.py -q` *(fails: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b4ce172c8329ad6d22bd07ddd4f5