### PR TITLE
Use monkeypatch to configure API key

### DIFF
--- a/tests/security/test_api_key_auth.py
+++ b/tests/security/test_api_key_auth.py
@@ -1,13 +1,14 @@
 import pytest
 
+from cognitive_core import config
 from cognitive_core.api import auth
-from cognitive_core.config import Settings
 
 
 @pytest.mark.integration
 def test_api_key_enforced(api_client, monkeypatch):
     monkeypatch.setenv("COG_API_KEY", "secret")
-    monkeypatch.setattr(auth, "settings", Settings())
+    monkeypatch.setattr(config, "settings", config.Settings())
+    monkeypatch.setattr(auth, "settings", config.settings)
 
     r = api_client.get("/api/health")
     assert r.status_code == 403


### PR DESCRIPTION
## Summary
- patch `COG_API_KEY` in tests using `monkeypatch.setenv`
- reload configuration settings so new API key is applied

## Testing
- `pre-commit run --files tests/security/test_api_key_auth.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit; No matching distribution found)*
- `pytest tests/security/test_api_key_auth.py` *(fails: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b4ce66f883298eb17bd9491aa4f5