### PR TITLE
Ensure FastAPI runtime packages and add dev requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,15 @@ version = "0.1.0"
 description = "Core engine with API, CLI, plugins, tests and CI"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["pydantic>=2.7", "typing-extensions>=4.8"]
+dependencies = [
+    "pydantic>=2.7",
+    "typing-extensions>=4.8",
+    "fastapi>=0.111",
+    "uvicorn>=0.29",
+]
 
 [project.optional-dependencies]
 api = [
-    "fastapi>=0.111",
-    "uvicorn>=0.29",
     "httpx>=0.25",
     "prometheus-client>=0.20",
     "opentelemetry-sdk>=1.24",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-e .[dev]
+fastapi>=0.111
+httpx>=0.25
+pytest>=7.4


### PR DESCRIPTION
## Summary
- include FastAPI and Uvicorn in core dependencies
- add a requirements-dev file with FastAPI, httpx, and pytest

## Testing
- ❌ `python -m pip install -e .[test,dev]` (missing setuptools due to network restrictions)
- ❌ `pytest` (failed: No module named 'fastapi')

------
https://chatgpt.com/codex/tasks/task_e_68c5b4cfd3948329aaf36d1df44faa07