### PR TITLE
feat: support multiple API keys

### DIFF
--- a/src/cognitive_core/api/auth.py
+++ b/src/cognitive_core/api/auth.py
@@ -4,21 +4,25 @@ from fastapi import Security, HTTPException, status
 from fastapi.security import APIKeyHeader
 
 from ..config import settings
+from ..utils.telemetry import Counter
 
 # Header name that clients must supply API keys in.
 api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+# Counter for failed authentication attempts
+API_KEY_FAILURES = Counter("api_key_auth_failures_total", "Invalid API key attempts")
 
 
 async def verify_api_key(api_key: str | None = Security(api_key_header)) -> None:
     """Validate the provided API key against configured settings.
 
-    Authentication is disabled when ``settings.api_key`` is ``None`` so all
-    requests are allowed. When configured (including an empty string), requests
-    must include the correct key in the ``X-API-Key`` header or a ``403`` is
-    raised.
+    Authentication is disabled when ``settings.api_keys`` is ``None`` so all
+    requests are allowed. When configured, requests must include one of the
+    configured keys in the ``X-API-Key`` header or a ``403`` is raised.
     """
-    if settings.api_key is None:
+    if settings.api_keys is None:
         return
 
-    if api_key != settings.api_key:
+    if api_key is None or api_key not in settings.api_keys:
+        API_KEY_FAILURES.inc()
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid API key")

--- a/src/cognitive_core/config/settings.py
+++ b/src/cognitive_core/config/settings.py
@@ -1,3 +1,4 @@
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -5,6 +6,15 @@ class Settings(BaseSettings):
     app_name: str = "Cognitive Core Engine"
     api_prefix: str = "/api"
     debug: bool = False
-    api_key: str | None = None
+    api_keys: list[str] | None = None
+
+    @field_validator("api_keys", mode="before")
+    @classmethod
+    def split_api_keys(cls, v: str | list[str] | None) -> list[str] | None:
+        if isinstance(v, str):
+            if v == "":
+                return [""]
+            return [k.strip() for k in v.split(",")]
+        return v
 
     model_config = SettingsConfigDict(env_file=".env", env_prefix="COG_")

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -8,15 +8,15 @@ from cognitive_core.config import Settings
 client = TestClient(app)
 
 
-def test_no_auth_when_api_key_none(monkeypatch):
-    monkeypatch.delenv("COG_API_KEY", raising=False)
+def test_no_auth_when_api_keys_none(monkeypatch):
+    monkeypatch.delenv("COG_API_KEYS", raising=False)
     monkeypatch.setattr(auth, "settings", Settings())
     r = client.get("/api/health")
     assert r.status_code == 200
 
 
-def test_requires_auth_when_api_key_empty(monkeypatch):
-    monkeypatch.setenv("COG_API_KEY", "")
+def test_requires_auth_when_api_keys_empty(monkeypatch):
+    monkeypatch.setenv("COG_API_KEYS", "")
     monkeypatch.setattr(auth, "settings", Settings())
     r = client.get("/api/health")
     assert r.status_code == 403

--- a/tests/security/test_api_key_auth.py
+++ b/tests/security/test_api_key_auth.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import Mock
 
 from cognitive_core.api import auth
 from cognitive_core.config import Settings
@@ -6,19 +7,23 @@ from cognitive_core.config import Settings
 
 @pytest.mark.integration
 def test_api_key_enforced(api_client, monkeypatch):
-    monkeypatch.setenv("COG_API_KEY", "secret")
+    monkeypatch.setenv("COG_API_KEYS", "secret")
     monkeypatch.setattr(auth, "settings", Settings())
+    mock_counter = Mock()
+    monkeypatch.setattr(auth, "API_KEY_FAILURES", mock_counter)
 
     r = api_client.get("/api/health")
     assert r.status_code == 403
+    mock_counter.inc.assert_called_once()
 
     r2 = api_client.get("/api/health", headers={"X-API-Key": "secret"})
     assert r2.status_code == 200
+    assert mock_counter.inc.call_count == 1
 
 
 @pytest.mark.integration
 def test_empty_api_key_requires_header(api_client, monkeypatch):
-    monkeypatch.setenv("COG_API_KEY", "")
+    monkeypatch.setenv("COG_API_KEYS", "")
     monkeypatch.setattr(auth, "settings", Settings())
 
     r = api_client.get("/api/health")

--- a/tests/security/test_api_key_optional.py
+++ b/tests/security/test_api_key_optional.py
@@ -6,7 +6,7 @@ from cognitive_core.config import Settings
 
 @pytest.mark.integration
 def test_health_without_api_key(api_client, monkeypatch):
-    monkeypatch.delenv("COG_API_KEY", raising=False)
+    monkeypatch.delenv("COG_API_KEYS", raising=False)
     monkeypatch.setattr(auth, "settings", Settings())
     response = api_client.get("/api/health")
     assert response.status_code == 200

--- a/tests/security/test_health_no_header_without_key.py
+++ b/tests/security/test_health_no_header_without_key.py
@@ -6,7 +6,7 @@ from cognitive_core.config import Settings
 
 @pytest.mark.integration
 def test_health_without_api_key_header(api_client, monkeypatch):
-    monkeypatch.delenv("COG_API_KEY", raising=False)
+    monkeypatch.delenv("COG_API_KEYS", raising=False)
     monkeypatch.setattr(auth, "settings", Settings())
     response = api_client.get("/api/health")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- support multiple API keys via comma-separated `COG_API_KEYS`
- validate API keys and log failed attempts with Prometheus counter
- test API key scenarios including counter increments

## Testing
- `pytest` *(fails: fastapi[test] not installed)*
- `pip install fastapi` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b75341308329a37449d6701e2c2d