### PR TITLE
Add Redis rate limiting middleware

### DIFF
--- a/src/cognitive_core/api/main.py
+++ b/src/cognitive_core/api/main.py
@@ -4,6 +4,7 @@ from fastapi.responses import Response
 from ..config import settings
 from ..utils.telemetry import setup_telemetry
 from .auth import verify_api_key
+from .rate_limit import RateLimitMiddleware
 try:  # pragma: no cover - allow running without prometheus-client installed
     from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 except Exception:  # pragma: no cover - fallback
@@ -14,6 +15,7 @@ from .routers import events, health, math, pipelines
 
 setup_telemetry(settings.app_name)
 app = FastAPI(title=settings.app_name, dependencies=[Depends(verify_api_key)])
+app.add_middleware(RateLimitMiddleware)
 # Register application routers
 app.include_router(health.router, prefix=settings.api_prefix, tags=["health"])
 app.include_router(math.router, prefix=settings.api_prefix, tags=["math"])

--- a/src/cognitive_core/api/rate_limit.py
+++ b/src/cognitive_core/api/rate_limit.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from fastapi import Request, status
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+
+from ..config import settings
+from ..rate_limiter import RedisBucketLimiter
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Middleware enforcing simple token-bucket rate limits using Redis."""
+
+    def __init__(self, app):
+        super().__init__(app)
+        try:
+            self.limiter = RedisBucketLimiter(
+                capacity=settings.rate_limit_burst,
+                refill_per_sec=settings.rate_limit_rps,
+            )
+        except Exception:
+            self.limiter = None
+
+    async def dispatch(self, request: Request, call_next):
+        if (
+            self.limiter
+            and request.url.path.startswith(settings.api_prefix)
+        ):
+            token = request.headers.get("X-API-Key")
+            if not token and request.client:
+                token = request.client.host
+            if token and not self.limiter.allow(token):
+                return Response(status_code=status.HTTP_429_TOO_MANY_REQUESTS)
+        return await call_next(request)

--- a/src/cognitive_core/config/settings.py
+++ b/src/cognitive_core/config/settings.py
@@ -6,5 +6,7 @@ class Settings(BaseSettings):
     api_prefix: str = "/api"
     debug: bool = False
     api_key: str | None = None
+    rate_limit_rps: float = 5.0
+    rate_limit_burst: int = 10
 
     model_config = SettingsConfigDict(env_file=".env", env_prefix="COG_")

--- a/tests/security/test_rate_limit.py
+++ b/tests/security/test_rate_limit.py
@@ -1,0 +1,34 @@
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cognitive_core.api import rate_limit
+from cognitive_core.api import main
+from cognitive_core import config
+
+
+class DummyLimiter:
+    def __init__(self, *args, **kwargs):
+        self.capacity = kwargs.get("capacity", 1)
+        self.tokens = self.capacity
+
+    def allow(self, token: str, needed: float = 1.0) -> bool:  # pragma: no cover - simple
+        if self.tokens >= needed:
+            self.tokens -= needed
+            return True
+        return False
+
+
+@pytest.mark.integration
+def test_rate_limit_blocks_after_burst(monkeypatch):
+    monkeypatch.setenv("COG_RATE_LIMIT_RPS", "0")
+    monkeypatch.setenv("COG_RATE_LIMIT_BURST", "2")
+    importlib.reload(config)
+    importlib.reload(rate_limit)
+    monkeypatch.setattr(rate_limit, "RedisBucketLimiter", DummyLimiter)
+    importlib.reload(main)
+    client = TestClient(main.app)
+    assert client.get("/api/health").status_code == 200
+    assert client.get("/api/health").status_code == 200
+    assert client.get("/api/health").status_code == 429


### PR DESCRIPTION
## Summary
- enforce per-IP or API key token buckets using Redis middleware
- wire middleware into FastAPI app for all `/api/*` routes
- make rate limit settings configurable via environment
- add integration test covering burst blocking

## Testing
- `pre-commit run --files src/cognitive_core/api/rate_limit.py src/cognitive_core/api/main.py src/cognitive_core/config/settings.py tests/security/test_rate_limit.py` *(fails: pre-commit not installed)*
- `pytest tests/security/test_rate_limit.py` *(fails: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68c5b753c14483299b34d3305c349888