### PR TITLE
Enhance API key authentication tests and support multiple keys

### DIFF
--- a/src/cognitive_core/api/auth.py
+++ b/src/cognitive_core/api/auth.py
@@ -13,12 +13,14 @@ async def verify_api_key(api_key: str | None = Security(api_key_header)) -> None
     """Validate the provided API key against configured settings.
 
     Authentication is disabled when ``settings.api_key`` is ``None`` so all
-    requests are allowed. When configured (including an empty string), requests
-    must include the correct key in the ``X-API-Key`` header or a ``403`` is
-    raised.
+    requests are allowed. When configured (including an empty string or multiple
+    comma-separated keys), requests must include one of the configured keys in
+    the ``X-API-Key`` header or a ``403`` is raised.
     """
-    if settings.api_key is None:
+    configured = settings.api_key
+    if configured is None:
         return
 
-    if api_key != settings.api_key:
+    valid_keys = {k.strip() for k in configured.split(",")}
+    if api_key not in valid_keys:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid API key")

--- a/tests/security/test_api_key_auth.py
+++ b/tests/security/test_api_key_auth.py
@@ -1,4 +1,5 @@
 import pytest
+from hypothesis import assume, given, strategies as st
 
 from cognitive_core.api import auth
 from cognitive_core.config import Settings
@@ -17,6 +18,15 @@ def test_api_key_enforced(api_client, monkeypatch):
 
 
 @pytest.mark.integration
+def test_no_api_key_configured(api_client, monkeypatch):
+    monkeypatch.delenv("COG_API_KEY", raising=False)
+    monkeypatch.setattr(auth, "settings", Settings())
+
+    r = api_client.get("/api/health")
+    assert r.status_code == 200
+
+
+@pytest.mark.integration
 def test_empty_api_key_requires_header(api_client, monkeypatch):
     monkeypatch.setenv("COG_API_KEY", "")
     monkeypatch.setattr(auth, "settings", Settings())
@@ -26,3 +36,32 @@ def test_empty_api_key_requires_header(api_client, monkeypatch):
 
     r2 = api_client.get("/api/health", headers={"X-API-Key": ""})
     assert r2.status_code == 200
+
+
+@pytest.mark.integration
+def test_multiple_api_keys(api_client, monkeypatch):
+    monkeypatch.setenv("COG_API_KEY", "secret,altsecret")
+    monkeypatch.setattr(auth, "settings", Settings())
+
+    r_missing = api_client.get("/api/health")
+    assert r_missing.status_code == 403
+
+    r_valid = api_client.get("/api/health", headers={"X-API-Key": "secret"})
+    assert r_valid.status_code == 200
+
+    r_alt_valid = api_client.get("/api/health", headers={"X-API-Key": "altsecret"})
+    assert r_alt_valid.status_code == 200
+
+    r_invalid = api_client.get("/api/health", headers={"X-API-Key": "bad"})
+    assert r_invalid.status_code == 403
+
+
+@given(st.text())
+@pytest.mark.integration
+def test_random_invalid_keys_rejected(random_key, api_client, monkeypatch):
+    monkeypatch.setenv("COG_API_KEY", "secret")
+    monkeypatch.setattr(auth, "settings", Settings())
+
+    assume(random_key != "secret")
+    r = api_client.get("/api/health", headers={"X-API-Key": random_key})
+    assert r.status_code == 403


### PR DESCRIPTION
## Summary
- support comma-separated API keys in auth logic
- extend API key tests for missing, empty, multiple, and random invalid keys

## Testing
- `pytest tests/security/test_api_key_auth.py` *(fails: fastapi[test] not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b754a2f0832999ea329df2ed750e