### PR TITLE
docs: add env example and security guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Sample environment configuration
+# Rename to `.env` and adjust values before running the service
+
+# API keys (comma-separated)
+COG_API_KEYS=your_api_key_1,your_api_key_2
+
+# Optional single API key for compatibility
+COG_API_KEY=your_api_key
+
+# Rate limiting settings
+REDIS_URL=redis://localhost:6379/0
+RATE_LIMIT_CAPACITY=60
+RATE_LIMIT_REFILL_PER_SEC=1
+
+# LLM provider configuration
+OPENAI_API_KEY=
+OPENAI_API_BASE=https://api.openai.com/v1
+LLM_PROVIDER=mock
+ENABLE_COST_CALC=false

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 - [Встановлення](#встановлення)
 - [Швидкий старт](#швидкий-старт)
 - [API](#api)
+- [Security & Configuration](#security--configuration)
+  - [Troubleshooting](#troubleshooting)
 - [CLI](#cli)
 - [Тестування](#тестування)
 - [Architecture Overview / Огляд архітектури](#architecture-overview--огляд-архітектури)
@@ -70,6 +72,32 @@ curl -s -X POST http://localhost:8000/api/dot \
   -d '{"a": [1, 2, 3], "b": [4, 5, 6]}'
 # -> {"result": 32.0}
 ```
+
+## Security & Configuration
+
+Скопіюйте приклад конфігурації та налаштуйте ключі:
+
+```bash
+cp .env.example .env
+```
+
+Встановіть `COG_API_KEYS` (кома-розділений список) та інші змінні середовища.
+
+Приклад запиту з заголовком `X-API-Key`:
+
+```bash
+curl -H "X-API-Key: your_api_key" http://localhost:8000/api/health
+```
+
+Налаштування обмеження швидкості керуються змінними `REDIS_URL`,
+`RATE_LIMIT_CAPACITY` та `RATE_LIMIT_REFILL_PER_SEC`.
+
+### Troubleshooting
+
+- **Відсутні залежності.** Деякі функції потребують додаткових пакетів
+  (`redis`, `requests` тощо). Встановіть їх через `pip install -e '.[api,test,dev]'`.
+- **Файл `.env` не знайдено.** Переконайтеся, що скопіювали `.env.example`
+  у `.env` або експортували змінні вручну.
 
 ## CLI
 


### PR DESCRIPTION
## Summary
- provide `.env.example` with API key and rate-limit placeholders
- document security configuration and troubleshooting in README

## Testing
- `pytest` *(fails: fastapi[test] not installed)*
- `pip install fastapi` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b7557124832989ce8eb92de2c37e