### PR TITLE
chore: guard against egg-info directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,13 @@ jobs:
       has_docker: ${{ steps.detect.outputs.has_docker }}
     steps:
       - uses: actions/checkout@v4
+      - name: Ensure no egg-info directories are committed
+        run: |
+          if git ls-files | grep -q '\\.egg-info/'; then
+            echo "Error: tracked egg-info directories found:" >&2
+            git ls-files | grep '\\.egg-info/' >&2
+            exit 1
+          fi
       - id: detect
         run: |
           echo "has_python=false" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-# Ignore build-generated egg-info
-src/cognitive_core_engine.egg-info/
+# Ignore build-generated egg-info directories
+*.egg-info/


### PR DESCRIPTION
## Summary
- ignore generic `*.egg-info/` directories
- add CI step to fail when egg-info dirs are committed

## Testing
- `pip install pre-commit` *(failed: Tunnel connection failed: 403 Forbidden)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c5b755eb808329bb48b189cb77df5a