### PR TITLE
chore(config): enforce newline at EOF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# Editor configuration for cognitive-core-engine
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true

--- a/src/cognitive_core/config/__init__.py
+++ b/src/cognitive_core/config/__init__.py
@@ -8,4 +8,3 @@ from .settings import Settings
 settings = Settings()
 
 __all__ = ["Settings", "settings"]
-


### PR DESCRIPTION
## Summary
- ensure `src/cognitive_core/config/__init__.py` ends with a trailing newline
- add `.editorconfig` so editors enforce final newlines

## Testing
- `pre-commit run --files .editorconfig src/cognitive_core/config/__init__.py` *(fails: command not found)*
- `make lint` *(fails: ruff/bandit/mypy issues)*
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c5b758ea7c8329b21e0190add3e49a