### PR TITLE
chore: add newline after config exports

### DIFF
--- a/src/cognitive_core/config/__init__.py
+++ b/src/cognitive_core/config/__init__.py
@@ -8,3 +8,4 @@ from .settings import Settings
 settings = Settings()
 
 __all__ = ["Settings", "settings"]
+


### PR DESCRIPTION
## Summary
- ensure `src/cognitive_core/config/__init__.py` ends with a newline after exporting Settings

## Testing
- `pre-commit run --files src/cognitive_core/config/__init__.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx'; Skipped: fastapi[test] not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c6b39ca88329a2b5de4d6d730592