### PR TITLE
Ensure CI installs API extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           python -m pip install -U pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f pyproject.toml ]; then pip install .; fi
+          if [ -f pyproject.toml ]; then pip install -e .[api,test]; fi
           pip install ruff mypy bandit safety pytest coverage
       - name: Ruff
         run: ruff --output-format=github .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
--e .[dev]
+-e .[api,test,dev]
 fastapi>=0.111
 httpx>=0.25
 pytest>=7.4


### PR DESCRIPTION
## Summary
- install project using `[api,test]` extras in CI
- provide fallback requirements list including FastAPI, httpx, and pytest

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68c5c6be614c83299c1d0dcb087bff63