### PR TITLE
chore: ignore egg-info directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-# Ignore build-generated egg-info directories
+# Ignore Python egg-info directories
 *.egg-info/


### PR DESCRIPTION
## Summary
- drop accidental egg-info metadata
- ignore egg-info directories in git

## Testing
- `pre-commit run --files .gitignore` *(fails: pre-commit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c6c1ff588329b4eea5c20e1280d9