### PR TITLE
Add agents debate pipeline with role configs

### DIFF
--- a/config/agents/critic.yaml
+++ b/config/agents/critic.yaml
@@ -1,0 +1,3 @@
+name: critic
+system_prompt: "Highlight potential issues with the proposal."
+model: mock

--- a/config/agents/proponent.yaml
+++ b/config/agents/proponent.yaml
@@ -1,0 +1,3 @@
+name: proponent
+system_prompt: "Advocate for the proposal."
+model: mock

--- a/docs/aots_debate.md
+++ b/docs/aots_debate.md
@@ -1,0 +1,47 @@
+# AOTS Debate Pipeline
+
+This example demonstrates running multiple agent roles in a debate using
+`POST /api/pipelines/aots_debate`.
+
+## Role Profiles
+
+Store role configuration files in `config/agents/`:
+
+```yaml
+# config/agents/proponent.yaml
+name: proponent
+system_prompt: "Advocate for the proposal."
+model: mock
+```
+
+```yaml
+# config/agents/critic.yaml
+name: critic
+system_prompt: "Highlight potential issues with the proposal."
+model: mock
+```
+
+## Invoke the Pipeline
+
+```http
+POST /api/pipelines/aots_debate HTTP/1.1
+Content-Type: application/json
+
+{
+  "prompt": "Evaluate the proposal",
+  "roles": ["proponent", "critic"],
+  "concurrent": true
+}
+```
+
+Response:
+
+```json
+{
+  "prompt": "Evaluate the proposal",
+  "responses": {
+    "proponent": "<mock response...>",
+    "critic": "<mock response...>"
+  }
+}
+```

--- a/src/cognitive_core/core/agents_router.py
+++ b/src/cognitive_core/core/agents_router.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Iterable, List
+
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - fallback when PyYAML missing
+    yaml = None
+
+from ..domain.agents import AgentConfig, DebateRound, Role
+from ..llm.provider import get_provider
+
+
+class AgentsRouter:
+    """Utility to run multiple roles against a prompt sequentially or concurrently."""
+
+    def __init__(self, config_dir: str | Path = "config/agents"):
+        self.config_dir = Path(config_dir)
+        self.provider = get_provider()
+
+    # ------------------------------------------------------------------
+    # Configuration helpers
+    def load_role(self, name: str) -> AgentConfig:
+        """Load a role configuration from YAML."""
+
+        path = self.config_dir / f"{name}.yaml"
+        with path.open() as f:
+            if yaml:
+                data = yaml.safe_load(f) or {}
+            else:  # very small YAML subset parser
+                data = {}
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    if ":" in line:
+                        k, v = line.split(":", 1)
+                        data[k.strip()] = v.strip().strip('"').strip("'")
+        role = Role(name=data.get("name", name), system_prompt=data.get("system_prompt", ""))
+        model = data.get("model", "mock")
+        return AgentConfig(role=role, model=model)
+
+    def _prepare_prompt(self, cfg: AgentConfig, prompt: str) -> str:
+        return f"{cfg.role.system_prompt}\n\n{prompt}" if cfg.role.system_prompt else prompt
+
+    # ------------------------------------------------------------------
+    # Execution
+    def run(self, prompt: str, roles: Iterable[str], *, concurrent: bool = False) -> DebateRound:
+        configs = [self.load_role(r) for r in roles]
+        if concurrent:
+            return asyncio.run(self._run_concurrent(prompt, configs))
+        return self._run_sequential(prompt, configs)
+
+    def _run_sequential(self, prompt: str, configs: List[AgentConfig]) -> DebateRound:
+        round = DebateRound(prompt=prompt)
+        for cfg in configs:
+            r = self.provider.run(self._prepare_prompt(cfg, prompt))
+            round.responses[cfg.role.name] = r.get("text", "")
+        return round
+
+    async def _run_concurrent(self, prompt: str, configs: List[AgentConfig]) -> DebateRound:
+        round = DebateRound(prompt=prompt)
+
+        async def call(cfg: AgentConfig) -> None:
+            r = await asyncio.to_thread(self.provider.run, self._prepare_prompt(cfg, prompt))
+            round.responses[cfg.role.name] = r.get("text", "")
+
+        await asyncio.gather(*(call(cfg) for cfg in configs))
+        return round

--- a/src/cognitive_core/domain/__init__.py
+++ b/src/cognitive_core/domain/__init__.py
@@ -1,5 +1,6 @@
 """Domain models for cognitive core engine."""
 
+from .agents import AgentConfig, DebateRound, Role
 from .entities import Vector
 from .pipelines import Artifact, Event, Pipeline, Run
 
@@ -9,4 +10,7 @@ __all__ = [
     "Event",
     "Pipeline",
     "Run",
+    "Role",
+    "AgentConfig",
+    "DebateRound",
 ]

--- a/src/cognitive_core/domain/agents.py
+++ b/src/cognitive_core/domain/agents.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class Role:
+    """Represents a debating role executed by an agent."""
+
+    name: str
+    system_prompt: str
+
+
+@dataclass(frozen=True)
+class AgentConfig:
+    """Configuration for a single debating agent."""
+
+    role: Role
+    model: str = "mock"
+
+
+@dataclass
+class DebateRound:
+    """Container for the result of running a prompt through multiple roles."""
+
+    prompt: str
+    responses: Dict[str, str] = field(default_factory=dict)


### PR DESCRIPTION
## Summary
- add Role, AgentConfig, and DebateRound domain models
- implement AgentsRouter for sequential or concurrent role execution
- expose `/pipelines/aots_debate` API and provide YAML role examples

## Testing
- `pre-commit run --files src/cognitive_core/domain/agents.py src/cognitive_core/core/agents_router.py src/cognitive_core/api/routers/pipelines.py src/cognitive_core/domain/__init__.py config/agents/proponent.yaml config/agents/critic.yaml docs/aots_debate.md` *(command failed: pre-commit: command not found)*
- `pip install pre-commit` *(command failed: Could not find a version that satisfies the requirement pre-commit)*
- `pytest tests/test_pipelines_api.py::test_run_pipeline -q` *(command failed: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c6c54310832996bf35cf877b5dd3