### PR TITLE
Add ISR pipeline with plugin stages and metrics

### DIFF
--- a/src/cognitive_core/api/routers/pipelines.py
+++ b/src/cognitive_core/api/routers/pipelines.py
@@ -5,9 +5,14 @@ from pydantic import BaseModel
 
 from ...core.pipeline_executor import PipelineExecutor
 from ...domain.pipelines import Artifact, Pipeline
+from ...plugins import dispatch
+from ...plugins.plugin_loader import load_plugins
 from ...utils.telemetry import instrument_route, record_llm_tokens
 
 router = APIRouter()
+
+# Ensure plugins are loaded so pipeline stages are available
+load_plugins()
 
 
 # In-memory registry for demo purposes
@@ -47,4 +52,77 @@ def run_pipeline(req: RunRequest):
         "run_id": run.id,
         "status": run.status,
         "artifacts": [a.name for a in run.artifacts],
+    }
+
+
+class ISRRequest(BaseModel):
+    text: str
+
+
+@router.post("/pipelines/isr_run")
+@instrument_route("isr_run")
+def run_isr(req: ISRRequest):
+    state = {"text": req.text}
+
+    def r_stage() -> Artifact:
+        res = dispatch("isr.r", {"text": state["text"]})
+        state["text"] = res["text"]
+        return Artifact(
+            name="r",
+            data=res["text"],
+            logic=res.get("logic"),
+            semantic=res.get("semantic"),
+            narrative=res.get("narrative"),
+        )
+
+    def i_stage() -> Artifact:
+        res = dispatch("isr.i", {"text": state["text"]})
+        state["text"] = res["text"]
+        return Artifact(
+            name="i",
+            data=res["text"],
+            logic=res.get("logic"),
+            semantic=res.get("semantic"),
+            narrative=res.get("narrative"),
+        )
+
+    def p_stage() -> Artifact:
+        res = dispatch("isr.p", {"text": state["text"]})
+        state["text"] = res["text"]
+        return Artifact(
+            name="p",
+            data=res["text"],
+            logic=res.get("logic"),
+            semantic=res.get("semantic"),
+            narrative=res.get("narrative"),
+        )
+
+    def omega_stage() -> Artifact:
+        res = dispatch("isr.omega", {"text": state["text"]})
+        state["text"] = res["text"]
+        return Artifact(
+            name="omega",
+            data=res["text"],
+            logic=res.get("logic"),
+            semantic=res.get("semantic"),
+            narrative=res.get("narrative"),
+        )
+
+    pipeline = Pipeline(id="isr", name="ISR", steps=[r_stage, i_stage, p_stage, omega_stage])
+    run = executor.execute(pipeline)
+    record_llm_tokens("isr_run", len(run.artifacts))
+    return {
+        "run_id": run.id,
+        "status": run.status,
+        "output": state["text"],
+        "artifacts": [
+            {
+                "name": a.name,
+                "data": a.data,
+                "logic": a.logic,
+                "semantic": a.semantic,
+                "narrative": a.narrative,
+            }
+            for a in run.artifacts
+        ],
     }

--- a/src/cognitive_core/domain/pipelines.py
+++ b/src/cognitive_core/domain/pipelines.py
@@ -10,6 +10,9 @@ class Artifact:
 
     name: str
     data: Any
+    logic: float | None = None
+    semantic: float | None = None
+    narrative: float | None = None
 
 
 @dataclass(frozen=True)

--- a/src/cognitive_core/plugins/isr/__init__.py
+++ b/src/cognitive_core/plugins/isr/__init__.py
@@ -1,0 +1,1 @@
+"""ISR pipeline stage plugins."""

--- a/src/cognitive_core/plugins/isr/i.py
+++ b/src/cognitive_core/plugins/isr/i.py
@@ -1,0 +1,16 @@
+from .. import PluginMetadata, register
+
+
+class IStage:
+    """Integration stage."""
+
+    name = "isr.i"
+
+    def run(self, payload: dict) -> dict:
+        text = payload.get("text", "")
+        text = f"{text} -> I"
+        return {"text": text, "logic": 0.2, "semantic": 0.2, "narrative": 0.2}
+
+
+metadata = PluginMetadata(name="isr.i", version="1.0.0", requirements=[])
+register(IStage(), metadata)

--- a/src/cognitive_core/plugins/isr/omega.py
+++ b/src/cognitive_core/plugins/isr/omega.py
@@ -1,0 +1,16 @@
+from .. import PluginMetadata, register
+
+
+class OmegaStage:
+    """Final synthesis stage."""
+
+    name = "isr.omega"
+
+    def run(self, payload: dict) -> dict:
+        text = payload.get("text", "")
+        text = f"{text} -> Omega"
+        return {"text": text, "logic": 0.4, "semantic": 0.4, "narrative": 0.4}
+
+
+metadata = PluginMetadata(name="isr.omega", version="1.0.0", requirements=[])
+register(OmegaStage(), metadata)

--- a/src/cognitive_core/plugins/isr/p.py
+++ b/src/cognitive_core/plugins/isr/p.py
@@ -1,0 +1,16 @@
+from .. import PluginMetadata, register
+
+
+class PStage:
+    """Processing stage."""
+
+    name = "isr.p"
+
+    def run(self, payload: dict) -> dict:
+        text = payload.get("text", "")
+        text = f"{text} -> P"
+        return {"text": text, "logic": 0.3, "semantic": 0.3, "narrative": 0.3}
+
+
+metadata = PluginMetadata(name="isr.p", version="1.0.0", requirements=[])
+register(PStage(), metadata)

--- a/src/cognitive_core/plugins/isr/r.py
+++ b/src/cognitive_core/plugins/isr/r.py
@@ -1,0 +1,16 @@
+from .. import PluginMetadata, register
+
+
+class RStage:
+    """Initial reflection stage."""
+
+    name = "isr.r"
+
+    def run(self, payload: dict) -> dict:
+        text = payload.get("text", "")
+        text = f"{text} -> R"
+        return {"text": text, "logic": 0.1, "semantic": 0.1, "narrative": 0.1}
+
+
+metadata = PluginMetadata(name="isr.r", version="1.0.0", requirements=[])
+register(RStage(), metadata)

--- a/tests/pipelines/test_isr_run.py
+++ b/tests/pipelines/test_isr_run.py
@@ -1,0 +1,8 @@
+
+def test_isr_run(api_client):
+    resp = api_client.post("/api/pipelines/isr_run", json={"text": "hello"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "completed"
+    assert data["output"] == "hello -> R -> I -> P -> Omega"
+    assert [a["name"] for a in data["artifacts"]] == ["r", "i", "p", "omega"]


### PR DESCRIPTION
## Summary
- extend `Artifact` with logic, semantic, and narrative metrics
- add ISR stage plugins and chain them in a new pipeline
- expose `POST /api/pipelines/isr_run` and demo test

## Testing
- `pytest tests/pipelines/test_isr_run.py tests/test_pipelines_api.py` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68c5c6c82cdc83299a11a207b6aa2d46