### PR TITLE
feat: add memory adapters with auto context selection

### DIFF
--- a/src/cognitive_core/core/memory/__init__.py
+++ b/src/cognitive_core/core/memory/__init__.py
@@ -1,0 +1,11 @@
+"""Memory adapter implementations."""
+
+from .base import MemoryAdapter
+from .faiss_adapter import FaissMemoryAdapter
+from .sqlitevec_adapter import SQLiteVecMemoryAdapter
+
+__all__ = [
+    "MemoryAdapter",
+    "FaissMemoryAdapter",
+    "SQLiteVecMemoryAdapter",
+]

--- a/src/cognitive_core/core/memory/base.py
+++ b/src/cognitive_core/core/memory/base.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Base classes for memory adapters."""
+
+from abc import ABC, abstractmethod
+from typing import List
+
+
+class MemoryAdapter(ABC):
+    """Abstract interface for memory vector stores.
+
+    Concrete implementations are responsible for persisting pieces of text
+    and later retrieving the most relevant ones for a given query.  The
+    interface intentionally keeps the API minimal so that different backing
+    stores (e.g. FAISS, SQLiteVec) can provide a common behaviour that tests
+    and higher level components can rely upon.
+    """
+
+    @abstractmethod
+    def save(self, text: str) -> None:
+        """Persist a piece of text into the store."""
+
+    @abstractmethod
+    def retrieve(self, query: str, top_k: int = 1) -> List[str]:
+        """Return up to ``top_k`` pieces of text that best match ``query``."""

--- a/src/cognitive_core/core/memory/faiss_adapter.py
+++ b/src/cognitive_core/core/memory/faiss_adapter.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Simplified FAISS adapter used for tests."""
+
+from collections import Counter
+import math
+from typing import List, Tuple
+
+from .base import MemoryAdapter
+
+
+def _embed(text: str) -> Counter[str]:
+    """Create a naive bag-of-words embedding."""
+    return Counter(text.lower().split())
+
+
+def _cosine(a: Counter[str], b: Counter[str]) -> float:
+    """Compute cosine similarity between two bag-of-words vectors."""
+    intersection = set(a) & set(b)
+    dot = sum(a[token] * b[token] for token in intersection)
+    norm_a = math.sqrt(sum(v * v for v in a.values()))
+    norm_b = math.sqrt(sum(v * v for v in b.values()))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+class FaissMemoryAdapter(MemoryAdapter):
+    """In-memory implementation mimicking a FAISS vector store."""
+
+    def __init__(self) -> None:
+        self._store: List[Tuple[Counter[str], str]] = []
+
+    def save(self, text: str) -> None:
+        self._store.append((_embed(text), text))
+
+    def retrieve(self, query: str, top_k: int = 1) -> List[str]:
+        query_emb = _embed(query)
+        ranked = sorted(
+            self._store,
+            key=lambda item: _cosine(query_emb, item[0]),
+            reverse=True,
+        )
+        return [text for _, text in ranked[:top_k]]

--- a/src/cognitive_core/core/memory/sqlitevec_adapter.py
+++ b/src/cognitive_core/core/memory/sqlitevec_adapter.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Simplified SQLiteVec adapter used for tests."""
+
+from collections import Counter
+import math
+from typing import List, Tuple
+
+from .base import MemoryAdapter
+
+
+def _embed(text: str) -> Counter[str]:
+    """Create a naive bag-of-words embedding."""
+    return Counter(text.lower().split())
+
+
+def _cosine(a: Counter[str], b: Counter[str]) -> float:
+    """Compute cosine similarity between two bag-of-words vectors."""
+    intersection = set(a) & set(b)
+    dot = sum(a[token] * b[token] for token in intersection)
+    norm_a = math.sqrt(sum(v * v for v in a.values()))
+    norm_b = math.sqrt(sum(v * v for v in b.values()))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+class SQLiteVecMemoryAdapter(MemoryAdapter):
+    """In-memory implementation mimicking a SQLiteVec vector store."""
+
+    def __init__(self) -> None:
+        self._store: List[Tuple[Counter[str], str]] = []
+
+    def save(self, text: str) -> None:
+        self._store.append((_embed(text), text))
+
+    def retrieve(self, query: str, top_k: int = 1) -> List[str]:
+        query_emb = _embed(query)
+        ranked = sorted(
+            self._store,
+            key=lambda item: _cosine(query_emb, item[0]),
+            reverse=True,
+        )
+        return [text for _, text in ranked[:top_k]]

--- a/tests/memory/test_adapters.py
+++ b/tests/memory/test_adapters.py
@@ -1,0 +1,17 @@
+import pytest
+
+from cognitive_core.core.memory.faiss_adapter import FaissMemoryAdapter
+from cognitive_core.core.memory.sqlitevec_adapter import SQLiteVecMemoryAdapter
+
+
+@pytest.mark.parametrize("adapter_cls", [FaissMemoryAdapter, SQLiteVecMemoryAdapter])
+def test_auto_context_selection(adapter_cls) -> None:
+    """Saving and retrieving selects the most relevant context automatically."""
+
+    adapter = adapter_cls()
+    adapter.save("Paris is the capital of France")
+    adapter.save("Berlin is the capital of Germany")
+    adapter.save("Rome is the capital of Italy")
+
+    results = adapter.retrieve("What is the capital of Germany?")
+    assert results[0] == "Berlin is the capital of Germany"


### PR DESCRIPTION
## Summary
- add `MemoryAdapter` base class for memory stores
- implement simple FAISS and SQLiteVec adapters with save/retrieve
- show auto-context selection in adapter tests

## Testing
- `pre-commit run --files src/cognitive_core/core/memory/__init__.py src/cognitive_core/core/memory/base.py src/cognitive_core/core/memory/faiss_adapter.py src/cognitive_core/core/memory/sqlitevec_adapter.py tests/memory/test_adapters.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `ruff check src/cognitive_core/core/memory/__init__.py src/cognitive_core/core/memory/base.py src/cognitive_core/core/memory/faiss_adapter.py src/cognitive_core/core/memory/sqlitevec_adapter.py tests/memory/test_adapters.py`
- `mypy src/cognitive_core/core/memory/__init__.py src/cognitive_core/core/memory/base.py src/cognitive_core/core/memory/faiss_adapter.py src/cognitive_core/core/memory/sqlitevec_adapter.py tests/memory/test_adapters.py`
- `black src/cognitive_core/core/memory/__init__.py src/cognitive_core/core/memory/base.py src/cognitive_core/core/memory/faiss_adapter.py src/cognitive_core/core/memory/sqlitevec_adapter.py tests/memory/test_adapters.py`
- `pytest tests/memory/test_adapters.py` *(fails: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c6c9b0a48329a22901354db4bdf5