### PR TITLE
chore: add trailing newline to config init

### DIFF
--- a/src/cognitive_core/config/__init__.py
+++ b/src/cognitive_core/config/__init__.py
@@ -9,3 +9,4 @@ settings = Settings()
 
 __all__ = ["Settings", "settings"]
 
+


### PR DESCRIPTION
## Summary
- ensure config package exposes trailing newline after `__all__`

## Testing
- `pre-commit run --files src/cognitive_core/config/__init__.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: 403 Forbidden)*
- `pytest` *(fails: httpx missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c6557ccc208329a106f9b4ffffd3ae