### PR TITLE
test: reload modules after setting API key

### DIFF
--- a/tests/security/test_api_key_auth.py
+++ b/tests/security/test_api_key_auth.py
@@ -1,3 +1,5 @@
+import importlib
+
 import pytest
 from hypothesis import assume, given, strategies as st
 
@@ -8,9 +10,8 @@ from cognitive_core.api import auth
 @pytest.mark.integration
 def test_api_key_enforced(api_client, monkeypatch):
     monkeypatch.setenv("COG_API_KEY", "secret")
-    settings = config.Settings()
-    monkeypatch.setattr(config, "settings", settings)
-    monkeypatch.setattr(auth, "settings", settings)
+    importlib.reload(config)
+    importlib.reload(auth)
 
     r = api_client.get("/api/health")
     assert r.status_code == 403
@@ -22,9 +23,8 @@ def test_api_key_enforced(api_client, monkeypatch):
 @pytest.mark.integration
 def test_no_api_key_configured(api_client, monkeypatch):
     monkeypatch.delenv("COG_API_KEY", raising=False)
-    settings = config.Settings()
-    monkeypatch.setattr(config, "settings", settings)
-    monkeypatch.setattr(auth, "settings", settings)
+    importlib.reload(config)
+    importlib.reload(auth)
 
     r = api_client.get("/api/health")
     assert r.status_code == 200
@@ -33,9 +33,8 @@ def test_no_api_key_configured(api_client, monkeypatch):
 @pytest.mark.integration
 def test_empty_api_key_requires_header(api_client, monkeypatch):
     monkeypatch.setenv("COG_API_KEY", "")
-    settings = config.Settings()
-    monkeypatch.setattr(config, "settings", settings)
-    monkeypatch.setattr(auth, "settings", settings)
+    importlib.reload(config)
+    importlib.reload(auth)
 
     r = api_client.get("/api/health")
     assert r.status_code == 403
@@ -47,9 +46,8 @@ def test_empty_api_key_requires_header(api_client, monkeypatch):
 @pytest.mark.integration
 def test_multiple_api_keys(api_client, monkeypatch):
     monkeypatch.setenv("COG_API_KEY", "secret,altsecret")
-    settings = config.Settings()
-    monkeypatch.setattr(config, "settings", settings)
-    monkeypatch.setattr(auth, "settings", settings)
+    importlib.reload(config)
+    importlib.reload(auth)
 
     r_missing = api_client.get("/api/health")
     assert r_missing.status_code == 403
@@ -68,9 +66,8 @@ def test_multiple_api_keys(api_client, monkeypatch):
 @pytest.mark.integration
 def test_random_invalid_keys_rejected(random_key, api_client, monkeypatch):
     monkeypatch.setenv("COG_API_KEY", "secret")
-    settings = config.Settings()
-    monkeypatch.setattr(config, "settings", settings)
-    monkeypatch.setattr(auth, "settings", settings)
+    importlib.reload(config)
+    importlib.reload(auth)
 
     assume(random_key != "secret")
     r = api_client.get("/api/health", headers={"X-API-Key": random_key})


### PR DESCRIPTION
## Summary
- reload config and auth modules after setting `COG_API_KEY` in API key auth tests

## Testing
- `pytest tests/security/test_api_key_auth.py::test_api_key_enforced -q` *(fails: fastapi[test] not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6557d15208329b28e439535d5d15d