### PR TITLE
chore: ignore egg-info artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-# Ignore build-generated egg-info directories
+# Ignore Python build-generated egg-info directories
 *.egg-info/


### PR DESCRIPTION
## Summary
- clarify `.gitignore` entry for egg-info directories

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68c6557e48fc8329b55ab65efe6f3109