### PR TITLE
chore: add newline after config exports

### DIFF
--- a/src/cognitive_core/config/__init__.py
+++ b/src/cognitive_core/config/__init__.py
@@ -10,3 +10,4 @@ settings = Settings()
 __all__ = ["Settings", "settings"]
 
 
+


### PR DESCRIPTION
## Summary
- append newline after __all__ export in config init to maintain formatting

## Testing
- `pytest` *(fails: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c658bc3fbc832994803edbbf8a30e1