### PR TITLE
Refactor API key tests to use environment variables

### DIFF
--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,24 +1,46 @@
+import importlib
+
 from fastapi.testclient import TestClient
 
 from cognitive_core.api.main import app
 from cognitive_core.api import auth
-from cognitive_core.config import Settings
+from cognitive_core import config
 
 
 client = TestClient(app)
 
 
+def _reload():
+    """Reload config and auth after environment changes."""
+    importlib.reload(config)
+    importlib.reload(auth)
+
+
 def test_no_auth_when_api_key_none(monkeypatch):
     monkeypatch.delenv("COG_API_KEY", raising=False)
-    monkeypatch.setattr(auth, "settings", Settings())
+    _reload()
     r = client.get("/api/health")
     assert r.status_code == 200
 
 
 def test_requires_auth_when_api_key_empty(monkeypatch):
     monkeypatch.setenv("COG_API_KEY", "")
-    monkeypatch.setattr(auth, "settings", Settings())
+    _reload()
     r = client.get("/api/health")
     assert r.status_code == 403
     r = client.get("/api/health", headers={"X-API-Key": ""})
     assert r.status_code == 200
+
+
+def test_allows_valid_api_key(monkeypatch):
+    monkeypatch.setenv("COG_API_KEY", "secret")
+    _reload()
+    r = client.get("/api/health", headers={"X-API-Key": "secret"})
+    assert r.status_code == 200
+
+
+def test_rejects_invalid_api_key(monkeypatch):
+    monkeypatch.setenv("COG_API_KEY", "secret")
+    _reload()
+    r = client.get("/api/health", headers={"X-API-Key": "bad"})
+    assert r.status_code == 403

--- a/tests/security/test_api_key_access.py
+++ b/tests/security/test_api_key_access.py
@@ -1,16 +1,18 @@
+import importlib
 import pytest
 
 pytest.importorskip("fastapi")
 pytest.importorskip("pydantic_settings")
 
 from cognitive_core.api import auth
-from cognitive_core.config import Settings
+from cognitive_core import config
 
 
 @pytest.mark.integration
 def test_health_without_api_key_unset(api_client, monkeypatch):
     monkeypatch.delenv("COG_API_KEY", raising=False)
-    monkeypatch.setattr(auth, "settings", Settings())
+    importlib.reload(config)
+    importlib.reload(auth)
 
     response = api_client.get("/api/health")
     assert response.status_code == 200
@@ -19,7 +21,8 @@ def test_health_without_api_key_unset(api_client, monkeypatch):
 @pytest.mark.integration
 def test_health_with_empty_api_key(api_client, monkeypatch):
     monkeypatch.setenv("COG_API_KEY", "")
-    monkeypatch.setattr(auth, "settings", Settings())
+    importlib.reload(config)
+    importlib.reload(auth)
 
     response = api_client.get("/api/health")
     assert response.status_code == 403

--- a/tests/security/test_api_key_auth.py
+++ b/tests/security/test_api_key_auth.py
@@ -77,9 +77,8 @@ def test_random_invalid_keys_rejected(random_key, api_client, monkeypatch):
 @pytest.mark.integration
 def test_health_allows_access_when_key_unset(api_client, monkeypatch):
     monkeypatch.delenv("COG_API_KEY", raising=False)
-    settings = config.Settings()
-    monkeypatch.setattr(config, "settings", settings)
-    monkeypatch.setattr(auth, "settings", settings)
+    importlib.reload(config)
+    importlib.reload(auth)
 
     response = api_client.get("/api/health")
     assert response.status_code == 200
@@ -88,9 +87,8 @@ def test_health_allows_access_when_key_unset(api_client, monkeypatch):
 @pytest.mark.integration
 def test_health_rejects_without_key_when_env_empty(api_client, monkeypatch):
     monkeypatch.setenv("COG_API_KEY", "")
-    settings = config.Settings()
-    monkeypatch.setattr(config, "settings", settings)
-    monkeypatch.setattr(auth, "settings", settings)
+    importlib.reload(config)
+    importlib.reload(auth)
 
     response = api_client.get("/api/health")
     assert response.status_code == 403

--- a/tests/security/test_api_key_optional.py
+++ b/tests/security/test_api_key_optional.py
@@ -1,12 +1,15 @@
+import importlib
 import pytest
 
 from cognitive_core.api import auth
-from cognitive_core.config import Settings
+from cognitive_core import config
 
 
 @pytest.mark.integration
 def test_health_without_api_key(api_client, monkeypatch):
     monkeypatch.delenv("COG_API_KEY", raising=False)
-    monkeypatch.setattr(auth, "settings", Settings())
+    importlib.reload(config)
+    importlib.reload(auth)
+
     response = api_client.get("/api/health")
     assert response.status_code == 200

--- a/tests/security/test_health_no_header_without_key.py
+++ b/tests/security/test_health_no_header_without_key.py
@@ -1,12 +1,15 @@
+import importlib
 import pytest
 
 from cognitive_core.api import auth
-from cognitive_core.config import Settings
+from cognitive_core import config
 
 
 @pytest.mark.integration
 def test_health_without_api_key_header(api_client, monkeypatch):
     monkeypatch.delenv("COG_API_KEY", raising=False)
-    monkeypatch.setattr(auth, "settings", Settings())
+    importlib.reload(config)
+    importlib.reload(auth)
+
     response = api_client.get("/api/health")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- reload config instead of direct settings assignment when adjusting `COG_API_KEY`
- add coverage for valid and invalid API key scenarios

## Testing
- `pytest tests/api/test_auth.py tests/security/test_api_key_optional.py tests/security/test_health_no_header_without_key.py tests/security/test_api_key_access.py tests/security/test_api_key_auth.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68c658bf28848329b80de3c84af1e516