### PR TITLE
Include httpx in core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "typing-extensions>=4.8",
     "fastapi>=0.111",
     "uvicorn>=0.29",
+    "httpx>=0.25",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add `httpx` to core dependencies
- confirm `requirements-dev.txt` lists `fastapi`, `httpx`, and `pytest` for requirement-file installs
- CI workflow installs package with `[api,test]` extras

## Testing
- `pip install pre-commit` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pip install -e .[api,test]` *(fails: Could not find a version that satisfies the requirement setuptools>=68)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68c658c3454083299d5a0318a7075783