### PR TITLE
Document security config and add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,19 @@
 # Sample environment configuration
-# Rename to `.env` and adjust values before running the service
+# Copy to `.env` and adjust values before running the service
 
-# API keys (comma-separated)
-COG_API_KEYS=your_api_key_1,your_api_key_2
+# Core settings
+COG_APP_NAME="Cognitive Core Engine"
+COG_API_PREFIX="/api"
+COG_DEBUG=false
 
-# Optional single API key for compatibility
+# API key for securing endpoints
 COG_API_KEY=your_api_key
 
-# Rate limiting settings
-REDIS_URL=redis://localhost:6379/0
-RATE_LIMIT_CAPACITY=60
-RATE_LIMIT_REFILL_PER_SEC=1
+# Rate limiting
+COG_RATE_LIMIT_RPS=5.0
+COG_RATE_LIMIT_BURST=10
 
-# LLM provider configuration
+# Optional LLM provider configuration
 OPENAI_API_KEY=
 OPENAI_API_BASE=https://api.openai.com/v1
 LLM_PROVIDER=mock

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ curl -s -X POST http://localhost:8000/api/dot \
 cp .env.example .env
 ```
 
-Встановіть `COG_API_KEYS` (кома-розділений список) та інші змінні середовища.
+У `.env` встановіть `COG_API_KEY` та інші змінні середовища
+(`COG_APP_NAME`, `COG_API_PREFIX`, `COG_RATE_LIMIT_RPS`, `COG_RATE_LIMIT_BURST`).
 
 Приклад запиту з заголовком `X-API-Key`:
 
@@ -89,8 +90,8 @@ cp .env.example .env
 curl -H "X-API-Key: your_api_key" http://localhost:8000/api/health
 ```
 
-Налаштування обмеження швидкості керуються змінними `REDIS_URL`,
-`RATE_LIMIT_CAPACITY` та `RATE_LIMIT_REFILL_PER_SEC`.
+Параметри обмеження швидкості контролюються змінними `COG_RATE_LIMIT_RPS`
+та `COG_RATE_LIMIT_BURST`.
 
 ### Troubleshooting
 


### PR DESCRIPTION
## Summary
- add example `.env` file with COG_* placeholders
- document Security & Configuration usage in README

## Testing
- `pytest` *(fails: missing httpx; API tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c658c390b8832984a1a070b98295d8