### PR TITLE
test: add health check without API key

### DIFF
--- a/tests/security/test_api_key_no_key.py
+++ b/tests/security/test_api_key_no_key.py
@@ -1,0 +1,12 @@
+import pytest
+
+from cognitive_core.api import auth
+from cognitive_core.config import Settings
+
+
+@pytest.mark.integration
+def test_health_without_api_key(api_client, monkeypatch):
+    monkeypatch.delenv("COG_API_KEY", raising=False)
+    monkeypatch.setattr(auth, "settings", Settings())
+    response = api_client.get("/api/health")
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- test API health endpoint without an API key set

## Testing
- `pytest tests/security/test_api_key_no_key.py -q` *(fails: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c65aa699ac832998bbc085e1d43200