### PR TITLE
test: use monkeypatch for API key settings

### DIFF
--- a/tests/security/test_api_key_auth.py
+++ b/tests/security/test_api_key_auth.py
@@ -1,5 +1,3 @@
-import importlib
-
 import pytest
 from hypothesis import assume, given, strategies as st
 
@@ -10,8 +8,9 @@ from cognitive_core.api import auth
 @pytest.mark.integration
 def test_api_key_enforced(api_client, monkeypatch):
     monkeypatch.setenv("COG_API_KEY", "secret")
-    importlib.reload(config)
-    importlib.reload(auth)
+    settings = config.Settings()
+    monkeypatch.setattr(config, "settings", settings)
+    monkeypatch.setattr(auth, "settings", settings)
 
     r = api_client.get("/api/health")
     assert r.status_code == 403
@@ -23,8 +22,9 @@ def test_api_key_enforced(api_client, monkeypatch):
 @pytest.mark.integration
 def test_no_api_key_configured(api_client, monkeypatch):
     monkeypatch.delenv("COG_API_KEY", raising=False)
-    importlib.reload(config)
-    importlib.reload(auth)
+    settings = config.Settings()
+    monkeypatch.setattr(config, "settings", settings)
+    monkeypatch.setattr(auth, "settings", settings)
 
     r = api_client.get("/api/health")
     assert r.status_code == 200
@@ -33,8 +33,9 @@ def test_no_api_key_configured(api_client, monkeypatch):
 @pytest.mark.integration
 def test_empty_api_key_requires_header(api_client, monkeypatch):
     monkeypatch.setenv("COG_API_KEY", "")
-    importlib.reload(config)
-    importlib.reload(auth)
+    settings = config.Settings()
+    monkeypatch.setattr(config, "settings", settings)
+    monkeypatch.setattr(auth, "settings", settings)
 
     r = api_client.get("/api/health")
     assert r.status_code == 403
@@ -46,8 +47,9 @@ def test_empty_api_key_requires_header(api_client, monkeypatch):
 @pytest.mark.integration
 def test_multiple_api_keys(api_client, monkeypatch):
     monkeypatch.setenv("COG_API_KEY", "secret,altsecret")
-    importlib.reload(config)
-    importlib.reload(auth)
+    settings = config.Settings()
+    monkeypatch.setattr(config, "settings", settings)
+    monkeypatch.setattr(auth, "settings", settings)
 
     r_missing = api_client.get("/api/health")
     assert r_missing.status_code == 403
@@ -66,8 +68,9 @@ def test_multiple_api_keys(api_client, monkeypatch):
 @pytest.mark.integration
 def test_random_invalid_keys_rejected(random_key, api_client, monkeypatch):
     monkeypatch.setenv("COG_API_KEY", "secret")
-    importlib.reload(config)
-    importlib.reload(auth)
+    settings = config.Settings()
+    monkeypatch.setattr(config, "settings", settings)
+    monkeypatch.setattr(auth, "settings", settings)
 
     assume(random_key != "secret")
     r = api_client.get("/api/health", headers={"X-API-Key": random_key})


### PR DESCRIPTION
## Summary
- use `monkeypatch.setenv` to manage `COG_API_KEY` in API key tests
- reinitialize `Settings` after patching environment variables

## Testing
- `pytest tests/security/test_api_key_auth.py` *(fails: Skipped: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c65aa755408329b47818c58b552087