### PR TITLE
chore: ignore egg-info metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore Python egg-info directories
 *.egg-info/
+# Prevent packaging metadata from being tracked


### PR DESCRIPTION
## Summary
- add a note to `.gitignore` ensuring egg-info metadata is ignored
- remove stray `src/cognitive_core_engine.egg-info` directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx'; Skipped: fastapi[test] not installed; skipping API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c65aa7f7d4832984d91ccffd7192fb