### PR TITLE
Add in-memory rate limit fallback when Redis is unavailable

### DIFF
--- a/src/cognitive_core/config/settings.py
+++ b/src/cognitive_core/config/settings.py
@@ -1,5 +1,14 @@
 from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+
+try:  # pragma: no cover - allow operation without optional dependency
+    from pydantic_settings import BaseSettings, SettingsConfigDict
+except ModuleNotFoundError:  # pragma: no cover - fallback shim
+    from pydantic import BaseModel, ConfigDict
+
+    class BaseSettings(BaseModel):
+        model_config = ConfigDict()
+
+    SettingsConfigDict = ConfigDict
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
## Summary
- add an in-memory token bucket fallback in the API rate limit middleware and log when Redis is unavailable
- allow configuration settings to fall back when `pydantic-settings` is absent
- add unit tests that exercise the in-memory limiter behaviour

## Testing
- pytest tests/unit/test_rate_limit.py

------
https://chatgpt.com/codex/tasks/task_e_68c83f81decc8329b866dba6dbacf1fb