### PR TITLE
Run Docker image as non-root appuser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,27 @@
-
 FROM python:3.12-slim
-WORKDIR /app
+
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
-COPY . /app
-RUN pip install --upgrade pip && pip install --no-cache-dir requests httpx redis sqlalchemy alembic psycopg2-binary prometheus-client structlog
+WORKDIR /app
+
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir \
+        requests \
+        httpx \
+        redis \
+        sqlalchemy \
+        alembic \
+        psycopg2-binary \
+        prometheus-client \
+        structlog
+
+RUN groupadd -g 1000 appuser \
+    && useradd -m -u 1000 -g appuser appuser \
+    && chown -R appuser:appuser /app
+
+USER appuser
+
+COPY --chown=appuser:appuser . /app
+
 EXPOSE 8000
 CMD ["uvicorn", "cognitive_core.api.main:app", "--host", "0.0.0.0", "--port", "8000"]
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -29,6 +29,12 @@ Steps:
    docker compose logs -f api
    ```
 
+> **Note:** The Docker image runs as the unprivileged `appuser` account. If you override the compose configuration to mount a local path into `/app`, ensure the mounted directory grants read (and write, if needed) access to UID 1000 inside the container. For example, adjust permissions on the host before starting services:
+> ```bash
+> sudo chown -R 1000:1000 /path/to/project
+> ```
+> Alternatively, use group-based permissions so that the directory is accessible without changing ownership.
+
 ## Observability
 ```mermaid
 flowchart LR


### PR DESCRIPTION
## Summary
- create a dedicated `appuser` in the Docker image, switch to it before copying the application, and adjust ownership so the app runs without root privileges
- document the permissions expectations for bind mounts when running the container under the unprivileged user

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c842a383808329891bd33d81d061ee