### PR TITLE
Add security headers and CORS configuration

### DIFF
--- a/src/cognitive_core/api/security.py
+++ b/src/cognitive_core/api/security.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+
+CallNext = Callable[[Request], Awaitable[Response]]
+
+
+class SecureHeadersMiddleware(BaseHTTPMiddleware):
+    """Middleware that adds common security headers to all responses."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        strict_transport_security: str = "max-age=63072000; includeSubDomains; preload",
+        x_frame_options: str = "DENY",
+        x_content_type_options: str = "nosniff",
+    ) -> None:
+        super().__init__(app)
+        self._strict_transport_security = strict_transport_security
+        self._x_frame_options = x_frame_options
+        self._x_content_type_options = x_content_type_options
+
+    async def dispatch(self, request: Request, call_next: CallNext) -> Response:
+        response = await call_next(request)
+
+        if self._strict_transport_security:
+            response.headers.setdefault(
+                "Strict-Transport-Security", self._strict_transport_security
+            )
+        if self._x_frame_options:
+            response.headers.setdefault("X-Frame-Options", self._x_frame_options)
+        if self._x_content_type_options:
+            response.headers.setdefault(
+                "X-Content-Type-Options", self._x_content_type_options
+            )
+
+        return response

--- a/src/cognitive_core/config/settings.py
+++ b/src/cognitive_core/config/settings.py
@@ -24,5 +24,9 @@ class Settings(BaseSettings):
     )
     rate_limit_rps: float = 5.0
     rate_limit_burst: int = 10
+    allowed_origins: list[str] = Field(
+        default_factory=list,
+        description="List of allowed CORS origins for the public API.",
+    )
 
     model_config = SettingsConfigDict(env_file=".env", env_prefix="COG_")

--- a/tests/api/test_root.py
+++ b/tests/api/test_root.py
@@ -1,17 +1,32 @@
 from fastapi.testclient import TestClient
 
+from cognitive_core import config
 from cognitive_core.api.main import app
+
+API_KEY = "test-key"
 
 client = TestClient(app)
 
 
+def _authorized_get(path: str):
+    config.settings.api_key = API_KEY
+    return client.get(path, headers={"X-API-Key": API_KEY})
+
+
 def test_root_endpoint():
-    r = client.get("/")
+    r = _authorized_get("/")
     assert r.status_code == 200
     assert "name" in r.json()
 
 
 def test_health_endpoint():
-    r = client.get("/api/health")
+    r = _authorized_get("/api/health")
     assert r.status_code == 200
     assert r.json()["status"] == "ok"
+
+
+def test_security_headers_present():
+    r = _authorized_get("/")
+    assert r.headers.get("strict-transport-security") == "max-age=63072000; includeSubDomains; preload"
+    assert r.headers.get("x-frame-options") == "DENY"
+    assert r.headers.get("x-content-type-options") == "nosniff"


### PR DESCRIPTION
## Summary
- add a SecureHeadersMiddleware to attach strict transport, frame, and content-type protections to every response
- configure CORS via FastAPI using a new Settings.allowed_origins option and extend the settings stub to realize Field defaults
- cover the new headers with API tests that inject a temporary API key for the TestClient

## Testing
- pytest tests/api/test_root.py
- pytest tests/api

------
https://chatgpt.com/codex/tasks/task_e_68c84f12a62483298d0decca78c41579