### PR TITLE
Validate OpenAI API base URL

### DIFF
--- a/tests/unit/test_llm_provider_cost.py
+++ b/tests/unit/test_llm_provider_cost.py
@@ -1,3 +1,5 @@
+import pytest
+
 from cognitive_core.llm import provider as provider_module
 from cognitive_core.llm.costs import compute_cost_from_usage
 from cognitive_core.llm.provider import OpenAIAdapter
@@ -31,3 +33,13 @@ def test_cost_computation_with_usage(monkeypatch):
     expected = compute_cost_from_usage(adapter.model, usage)
     assert result["_cost_usd"] == expected
     assert result["_usage"] == usage
+
+
+def test_openai_adapter_rejects_unapproved_api_base(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_API_BASE", "https://evil.example.com/v1")
+
+    adapter = OpenAIAdapter()
+
+    with pytest.raises(RuntimeError):
+        adapter.run("hello")


### PR DESCRIPTION
## Summary
- parse `OPENAI_API_BASE` with `urllib.parse` and enforce HTTPS plus an allow list of hosts
- raise a runtime error when the OpenAI API base fails validation
- add a unit test that verifies unsafe API bases are rejected

## Testing
- pytest tests/unit/test_llm_provider_cost.py

------
https://chatgpt.com/codex/tasks/task_e_68c91558ad748329aab6d1fb3589af5e