### PR TITLE
Enforce API key verification when header missing

### DIFF
--- a/src/cognitive_core/api/auth.py
+++ b/src/cognitive_core/api/auth.py
@@ -46,9 +46,14 @@ async def verify_api_key(api_key: str | None = Security(api_key_header)) -> None
             detail="API key configuration invalid",
         )
 
-    provided_key = api_key or ""
+    if api_key is None:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="API key required")
+
+    provided_key = api_key
+    is_valid = False
     for valid_key in valid_keys:
         if hmac.compare_digest(valid_key, provided_key):
-            break
-    else:
+            is_valid = True
+
+    if not is_valid:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid API key")

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -61,3 +61,15 @@ def test_verify_api_key_rejects_spoofed_value(monkeypatch):
         asyncio.run(auth.verify_api_key("spoofed"))
 
     assert exc.value.status_code == 403
+
+
+def test_verify_api_key_rejects_missing_value(monkeypatch):
+    """Simulate tampering by stripping the API key header entirely."""
+
+    monkeypatch.setenv("COG_API_KEY", "secret")
+    _reload()
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(auth.verify_api_key(None))
+
+    assert exc.value.status_code == 403


### PR DESCRIPTION
## Summary
- ensure API key verification rejects requests without the header by raising HTTP 403
- validate provided keys against every configured value using hmac.compare_digest
- add a regression test covering tampered requests that strip the API key header

## Testing
- pytest tests/api/test_auth.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c929a2e7648329a0b9b777752ce0ed