### PR TITLE
Add configurable security headers and CORS middleware

### DIFF
--- a/src/cognitive_core/api/main.py
+++ b/src/cognitive_core/api/main.py
@@ -18,9 +18,6 @@ from .routers import events, health, math, pipelines
 setup_telemetry(settings.app_name)
 app = FastAPI(title=settings.app_name, dependencies=[Depends(verify_api_key)])
 app.add_middleware(
-    SecureHeadersMiddleware,
-)
-app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.allowed_origins,
     allow_credentials=True,
@@ -28,6 +25,9 @@ app.add_middleware(
     allow_headers=["*"],
 )
 app.add_middleware(RateLimitMiddleware)
+app.add_middleware(
+    SecureHeadersMiddleware,
+)
 # Register application routers
 app.include_router(health.router, prefix=settings.api_prefix, tags=["health"])
 app.include_router(math.router, prefix=settings.api_prefix, tags=["math"])

--- a/src/cognitive_core/config/settings.py
+++ b/src/cognitive_core/config/settings.py
@@ -1,4 +1,9 @@
-from pydantic import Field
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable
+
+from pydantic import Field, field_validator
 
 try:  # pragma: no cover - allow operation without optional dependency
     from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -28,5 +33,35 @@ class Settings(BaseSettings):
         default_factory=list,
         description="List of allowed CORS origins for the public API.",
     )
+
+    @field_validator("allowed_origins", mode="before")
+    @classmethod
+    def _parse_allowed_origins(cls, value: Any) -> list[str]:
+        if value is None:
+            return []
+
+        if isinstance(value, str):
+            raw_value = value.strip()
+            if not raw_value:
+                return []
+
+            try:
+                parsed = json.loads(raw_value)
+            except json.JSONDecodeError:
+                candidates: Iterable[str] = raw_value.split(",")
+            else:
+                if isinstance(parsed, str):
+                    candidates = [parsed]
+                elif isinstance(parsed, Iterable):
+                    candidates = parsed
+                else:
+                    raise TypeError("allowed_origins must be a string or iterable of strings")
+
+            return [item.strip() for item in candidates if str(item).strip()]
+
+        if isinstance(value, Iterable):
+            return [str(item).strip() for item in value if str(item).strip()]
+
+        return [str(value).strip()]
 
     model_config = SettingsConfigDict(env_file=".env", env_prefix="COG_")

--- a/tests/api/test_root.py
+++ b/tests/api/test_root.py
@@ -27,6 +27,9 @@ def test_health_endpoint():
 
 def test_security_headers_present():
     r = _authorized_get("/")
-    assert r.headers.get("strict-transport-security") == "max-age=63072000; includeSubDomains; preload"
-    assert r.headers.get("x-frame-options") == "DENY"
-    assert r.headers.get("x-content-type-options") == "nosniff"
+    assert (
+        r.headers["Strict-Transport-Security"]
+        == "max-age=63072000; includeSubDomains; preload"
+    )
+    assert r.headers["X-Frame-Options"] == "DENY"
+    assert r.headers["X-Content-Type-Options"] == "nosniff"


### PR DESCRIPTION
## Summary
- register CORS and security header middlewares on the FastAPI app
- allow configuring the list of allowed origins via Settings, including comma separated strings
- assert security headers are present on the root endpoint response

## Testing
- pytest tests/api/test_root.py

------
https://chatgpt.com/codex/tasks/task_e_68c929a487a083298c0243686eb4d01b