### PR TITLE
Validate OpenAI API base URL

### DIFF
--- a/tests/unit/test_llm_provider_cost.py
+++ b/tests/unit/test_llm_provider_cost.py
@@ -43,3 +43,13 @@ def test_openai_adapter_rejects_unapproved_api_base(monkeypatch):
 
     with pytest.raises(RuntimeError):
         adapter.run("hello")
+
+
+def test_openai_adapter_rejects_non_https_api_base(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_API_BASE", "http://api.openai.com/v1")
+
+    adapter = OpenAIAdapter()
+
+    with pytest.raises(RuntimeError):
+        adapter.run("hello")


### PR DESCRIPTION
## Summary
- validate and normalize the configured OpenAI API base URL so only https hosts from the whitelist are accepted
- reuse the sanitized base when building the completions endpoint
- add a unit test covering rejection of non-https API base values

## Testing
- pytest tests/unit/test_llm_provider_cost.py

------
https://chatgpt.com/codex/tasks/task_e_68c929a6ea688329a4693402f17fef78