### PR TITLE
Ensure CI reports directory exists and refresh badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,10 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f pyproject.toml ]; then pip install -e .[api,test]; fi
           pip install ruff mypy bandit safety pytest coverage
+      - name: Prepare reports directory
+        run: mkdir -p reports
       - name: Ruff
-        run: ruff --output-format=github .
+        run: ruff check . --output-format=github
       - name: Mypy
         run: mypy .
       - name: Bandit

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Базовий рушій для когнітивних сервісів із API, CLI та підтримкою плагінів.
 
-[![CI](https://img.shields.io/github/actions/workflow/status/neuron7x/cognitive-core-engine/ci.yml?style=flat-square&logo=github)](https://github.com/neuron7x/cognitive-core-engine/actions/workflows/ci.yml)
+[![CI](https://github.com/neuron7x/cognitive-core-engine/actions/workflows/ci.yml/badge.svg)](https://github.com/neuron7x/cognitive-core-engine/actions/workflows/ci.yml)
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/neuron7x/cognitive-core-engine/codeql.yml?style=flat-square&logo=github)](https://github.com/neuron7x/cognitive-core-engine/actions/workflows/codeql.yml)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue?style=flat-square&logo=python)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green?style=flat-square)](LICENSE)


### PR DESCRIPTION
## Summary
- ensure the Python workflow job creates the reports directory before writing artifacts
- call Ruff via `ruff check` for clearer intent
- switch the README build badge to GitHub's native workflow badge

## Testing
- ruff check . *(fails: existing Ruff findings in repository)*
- mypy . *(fails: duplicate module name between tests and legacy tree)*
- pytest *(fails: missing optional dependency `alembic` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c929a99c048329b0d36d435104525d