### PR TITLE
Add structured logging and observability middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased]
+- Added structured JSON logging with OpenTelemetry correlation and configurable
+  `COG_LOG_LEVEL`.
+- Introduced unified observability middleware exposing Prometheus request metrics
+  and request-scoped logging context.
+- Documented deployment, upgrade, and incident response runbooks in
+  `docs/operations.md` and expanded README observability guidance.
+
 ## v0.1.0 — 2025-09-12
 - Unified version to v0.1.0 across code and docs.
 - Moved runtime deps into `pyproject.toml`; thinned `requirements.txt` to `-e .[dev]`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Security & Configuration](#security--configuration)
   - [Troubleshooting](#troubleshooting)
 - [CLI](#cli)
+- [Observability / Спостережуваність](#observability--спостережуваність)
 - [Тестування](#тестування)
 - [Architecture Overview / Огляд архітектури](#architecture-overview--огляд-архітектури)
 - [Дорожня карта](#дорожня-карта)
@@ -28,10 +29,11 @@
 Проєкт включає API, CLI та інструменти для розробки.
 
 ## Особливості
-- Відкритий HTTP API на FastAPI  
-- CLI `cogctl`  
-- Плагінна система  
-- Тести та CI  
+- Відкритий HTTP API на FastAPI
+- CLI `cogctl`
+- Плагінна система
+- Тести та CI
+- Структуровані JSON-логи з метриками Prometheus та трасуванням OpenTelemetry
 
 ## Встановлення
 ```bash
@@ -87,6 +89,11 @@ cp .env.example .env
 налаштовано, тому безпечно використовувати репозиторій без попередньо
 визначеного секрету.
 
+Журнальний рівень регулюється змінною `COG_LOG_LEVEL` (`INFO` за промовчанням).
+Структуровані логи включають `request_id`, `http_method`, `http_route`,
+`http_status`, `duration_ms`, а також `trace_id`/`span_id`, якщо активовано
+OpenTelemetry трейсер.
+
 Приклад запиту з заголовком `X-API-Key`:
 
 ```bash
@@ -115,6 +122,21 @@ cogctl dotv 1,2,3 4,5,6
 # Розв'язання системи 2x2
 cogctl solve2x2 1 2 3 4 5 6
 # -> {"x": -4.0, "y": 4.5}
+```
+
+## Observability / Спостережуваність
+
+- Прометеєві метрики доступні на [`/metrics`](http://localhost:8000/metrics).
+- Middleware `ObservabilityMiddleware` забезпечує структуровані JSON-логи з
+  полями `request_id`, `http_status`, `duration_ms`, `client_ip` та
+  `trace_id`/`span_id` (коли активовано OpenTelemetry).
+- Встановіть `OTEL_EXPORTER_OTLP_ENDPOINT`, щоб надсилати трейси до OTLP
+  колектора (Jaeger, Tempo, New Relic тощо).
+
+Приклад запису логів:
+
+```json
+{"timestamp": "2025-09-12T10:15:33.102000+00:00", "level": "INFO", "logger": "cognitive_core.utils.telemetry", "message": "request.completed", "module": "telemetry", "function": "dispatch", "line": 198, "request_id": "9f6d4b1e8e7c4a7d9df2f1a4b9d7c1ad", "http_method": "GET", "http_route": "/api/health", "http_status": "200", "duration_ms": 4.12}
 ```
 
 ## Тестування

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -48,3 +48,66 @@ Steps:
    docker run -p 9090:9090 prom/prometheus
    ```
 3. Configure an OpenTelemetry collector (or Jaeger) and set `OTEL_EXPORTER_OTLP_ENDPOINT` to forward traces.
+
+Structured JSON logs are emitted to STDOUT by default. Correlated fields include:
+
+- `request_id`, `http_method`, `http_route`, `http_status`
+- `trace_id`/`span_id` when OpenTelemetry tracing is active
+- `duration_ms`, `client_ip`, and user-provided `extra` fields
+
+Tune verbosity through the `COG_LOG_LEVEL` environment variable. Use `DEBUG` when
+diagnosing incidents and revert to `INFO` in steady state to limit noise.
+
+## Deployment (Розгортання)
+
+1. **Підготуйте артефакти.** Зберіть Docker-образ та прогоніть авто-тести:
+   ```bash
+   docker build -t registry.example.com/cognitive-core:$(git rev-parse --short HEAD) .
+   pytest
+   ```
+2. **Оновіть конфігурацію середовища.** Переконайтеся, що в секретах
+   налаштовано `COG_API_KEY`, мережеві обмеження (`COG_ALLOWED_ORIGINS`),
+   журнальний рівень (`COG_LOG_LEVEL`) та параметри рейт-лімітера.
+3. **Застосуйте міграції бази (за потреби).**
+   ```bash
+   cogctl migrate up
+   ```
+4. **Розгорніть сервіс.** Використовуйте улюблену оркестрацію (Docker Compose,
+   Kubernetes, Nomad). Для Kubernetes додавайте readiness/liveness-проби, які
+   опитують `/api/health/ready` та `/api/health/live`.
+5. **Перевірте розгортання.**
+   ```bash
+   curl -H "X-API-Key: $COG_API_KEY" https://service.example.com/api/health
+   ```
+6. **Під'єднайте спостереження.** Додайте job у Prometheus для `/metrics` і
+   скеруйте OpenTelemetry експортер на колектор.
+
+## Updating (Оновлення)
+
+1. Перегляньте [CHANGELOG](../CHANGELOG.md) на предмет несумісних змін.
+2. Увімкніть розширене логування (`COG_LOG_LEVEL=DEBUG`) лише на одному інстансі
+   для моніторингу під час оновлення.
+3. Запустіть оновлені образи по одному (rolling update / blue-green). Переконайтеся,
+   що новий інстанс пройшов health-checkи, перш ніж виводити попередній.
+4. Після оновлення перевірте:
+   - `/metrics` — чи збираються нові метрики
+   - OpenTelemetry трейс у трейсінг-системі
+   - Відсутність помилок у структурованих логах
+5. Поверніть `COG_LOG_LEVEL` до робочого значення.
+
+## Incident Response / Аварійні процедури
+
+1. **Виявлення.** Слідкуйте за алертами Prometheus (latency, кількість 5xx) та
+   за лімітом токенів LLM.
+2. **Діагностика.** Використовуйте структуровані логи, відфільтрувавши їх за
+   `request_id` або `trace_id`. При потребі увімкніть `DEBUG` тільки на проблемному
+   вузлі.
+3. **Мітігація.**
+   - Перезапустіть API контейнер або зробіть `kubectl rollout restart` для
+     швидкого відновлення.
+   - Якщо зовнішній сервіс (БД, Redis) недоступний — переведіть трафік на
+     резервний екземпляр.
+4. **Відкат.** Зафіксуйте версію, яка працювала стабільно, і виконайте деплой
+   попереднього образу.
+5. **Постмортем.** Збережіть вибірку логів і трейси за період інциденту та
+   задокументуйте у внутрішньому звіті.

--- a/src/cognitive_core/cli.py
+++ b/src/cognitive_core/cli.py
@@ -10,7 +10,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+from .config import settings
 from .core.math_utils import dot, solve_2x2
+from .utils.logging import setup_logging
 
 
 def _run_alembic(*args: str) -> int:
@@ -63,8 +65,7 @@ def _install_allowlisted_plugin(module: str) -> None:
     digest = hashlib.sha256(module_path.read_bytes()).hexdigest()
     if digest != spec.sha256:
         raise PluginVerificationError(
-            "Plugin hash mismatch for '%s': expected %s but got %s"
-            % (module, spec.sha256, digest)
+            "Plugin hash mismatch for '%s': expected %s but got %s" % (module, spec.sha256, digest)
         )
 
     load_plugins()
@@ -178,6 +179,7 @@ def handle_args(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    setup_logging(settings.log_level)
     parser = build_parser()
     args = parser.parse_args(argv)
     return handle_args(args)
@@ -185,4 +187,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/src/cognitive_core/config/settings.py
+++ b/src/cognitive_core/config/settings.py
@@ -22,6 +22,10 @@ class Settings(BaseSettings):
             "Must be set via environment configuration before exposing the service."
         ),
     )
+    log_level: str = Field(
+        default="INFO",
+        description="Log level for structured logging (e.g., DEBUG, INFO, WARNING).",
+    )
     rate_limit_rps: float = 5.0
     rate_limit_burst: int = 10
     allowed_origins: list[str] = Field(

--- a/src/cognitive_core/utils/logging.py
+++ b/src/cognitive_core/utils/logging.py
@@ -1,8 +1,173 @@
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import importlib.util
+import json
 import logging
+import logging.config
+from datetime import datetime, timezone
+from typing import Any
+
+_LOG_CONTEXT: contextvars.ContextVar[dict[str, Any]] = contextvars.ContextVar(
+    "log_context", default={}
+)
+
+_DEFAULT_RECORD_FIELDS = {
+    "args",
+    "asctime",
+    "created",
+    "exc_info",
+    "exc_text",
+    "filename",
+    "funcName",
+    "levelname",
+    "levelno",
+    "lineno",
+    "module",
+    "msecs",
+    "message",
+    "msg",
+    "name",
+    "pathname",
+    "process",
+    "processName",
+    "relativeCreated",
+    "stack_info",
+    "thread",
+    "threadName",
+}
+
+_TRACE_SPEC = None
+if importlib.util.find_spec("opentelemetry") is not None:
+    _TRACE_SPEC = importlib.util.find_spec("opentelemetry.trace")
+
+if _TRACE_SPEC is not None:  # pragma: no branch - dependency optional
+    from opentelemetry import trace  # type: ignore
+else:  # pragma: no cover - executed when optional dependency missing
+    trace = None  # type: ignore[assignment]
+
+
+def _stringify(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_stringify(item) for item in value]
+    if isinstance(value, dict):
+        return {str(k): _stringify(v) for k, v in value.items()}
+    return repr(value)
+
+
+def get_log_context() -> dict[str, Any]:
+    return dict(_LOG_CONTEXT.get({}))
+
+
+def bind_log_context(**kwargs: Any) -> contextvars.Token[dict[str, Any]]:
+    current = get_log_context()
+    for key, value in kwargs.items():
+        if value is not None:
+            current[str(key)] = value
+    return _LOG_CONTEXT.set(current)
+
+
+def reset_log_context(token: contextvars.Token[dict[str, Any]]) -> None:
+    _LOG_CONTEXT.reset(token)
+
+
+class StructuredLogFormatter(logging.Formatter):
+    """Render log records as JSON with OpenTelemetry correlation."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_record: dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "module": record.module,
+            "function": record.funcName,
+            "line": record.lineno,
+        }
+
+        context = get_log_context()
+        if context:
+            log_record.update(context)
+
+        if trace is not None:
+            span = trace.get_current_span()
+            if span is not None:
+                span_context = span.get_span_context()
+                if getattr(span_context, "is_valid", False):
+                    log_record["trace_id"] = format(span_context.trace_id, "032x")
+                    log_record["span_id"] = format(span_context.span_id, "016x")
+
+        if record.exc_info:
+            log_record["exception"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            log_record["stack"] = self.formatStack(record.stack_info)
+
+        extras = {
+            key: _stringify(value)
+            for key, value in record.__dict__.items()
+            if key not in _DEFAULT_RECORD_FIELDS
+        }
+        if extras:
+            log_record.update(extras)
+
+        return json.dumps(log_record, ensure_ascii=False)
+
+
+def _resolve_level(level: str | int) -> int:
+    if isinstance(level, int):
+        return level
+    if isinstance(level, str):
+        candidate = logging.getLevelName(level.upper())
+        if isinstance(candidate, int):
+            return candidate
+    return logging.INFO
 
 
 def setup_logging(level: str = "INFO") -> None:
-    logging.basicConfig(
-        level=getattr(logging, level.upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s :: %(message)s",
+    """Configure structured logging for the application."""
+
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "structured": {
+                    "()": "cognitive_core.utils.logging.StructuredLogFormatter",
+                }
+            },
+            "handlers": {
+                "default": {
+                    "class": "logging.StreamHandler",
+                    "formatter": "structured",
+                    "level": _resolve_level(level),
+                }
+            },
+            "root": {
+                "level": _resolve_level(level),
+                "handlers": ["default"],
+            },
+        }
     )
+    logging.captureWarnings(True)
+
+
+@contextlib.contextmanager
+def log_context(**kwargs: Any):
+    token = bind_log_context(**kwargs)
+    try:
+        yield
+    finally:
+        reset_log_context(token)
+
+
+__all__ = [
+    "StructuredLogFormatter",
+    "bind_log_context",
+    "get_log_context",
+    "log_context",
+    "reset_log_context",
+    "setup_logging",
+]

--- a/src/cognitive_core/utils/telemetry.py
+++ b/src/cognitive_core/utils/telemetry.py
@@ -1,81 +1,255 @@
+from __future__ import annotations
+
 import asyncio
 import contextlib
+import importlib.util
+import logging
 import time
+import uuid
+from contextvars import Token
 from functools import wraps
+from typing import Any, Awaitable, Callable, TypeVar
 
-try:
-    from prometheus_client import Counter, Histogram
-except Exception:  # pragma: no cover - fallback when library missing
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+from .logging import bind_log_context, reset_log_context
+
+_PROMETHEUS_SPEC = importlib.util.find_spec("prometheus_client")
+if _PROMETHEUS_SPEC is not None:  # pragma: no branch - optional dependency
+    from prometheus_client import Counter, Histogram  # type: ignore
+else:  # pragma: no cover - executed when dependency missing
+
     class _Metric:
-        def labels(self, **_kwargs):
+        def labels(self, **_kwargs: Any):
             return self
 
-        def observe(self, *_args, **_kwargs):
+        def observe(self, *_args: Any, **_kwargs: Any) -> None:
             return None
 
-        def inc(self, *_args, **_kwargs):
+        def inc(self, *_args: Any, **_kwargs: Any) -> None:
             return None
 
-    def Histogram(*_args, **_kwargs):  # type: ignore[override]
+    def Histogram(*_args: Any, **_kwargs: Any):  # type: ignore[override]
         return _Metric()
 
-    def Counter(*_args, **_kwargs):  # type: ignore[override]
+    def Counter(*_args: Any, **_kwargs: Any):  # type: ignore[override]
         return _Metric()
 
-try:
-    from opentelemetry import trace
-    from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
-except Exception:  # pragma: no cover - fallback when library missing
-    trace = None  # type: ignore
+
+_TRACE_SPEC = None
+if importlib.util.find_spec("opentelemetry") is not None:
+    _TRACE_SPEC = importlib.util.find_spec("opentelemetry.trace")
+
+if _TRACE_SPEC is not None:  # pragma: no branch - optional dependency
+    from opentelemetry import trace  # type: ignore
+    from opentelemetry.trace import Status, StatusCode  # type: ignore
+else:  # pragma: no cover - executed when dependency missing
+    trace = None  # type: ignore[assignment]
+    Status = None  # type: ignore[assignment]
+    StatusCode = None  # type: ignore[assignment]
 
 
 REQUEST_LATENCY = Histogram("request_latency_seconds", "Request latency", ["route"])
+HTTP_REQUESTS = Counter(
+    "http_requests_total",
+    "Total HTTP requests processed by the API",
+    ["method", "route", "status"],
+)
+HTTP_REQUEST_DURATION = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request duration distribution",
+    ["method", "route", "status"],
+)
 LLM_TOKENS = Counter("llm_tokens_total", "LLM tokens processed", ["route"])
+
+logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
 
 
 def setup_telemetry(service_name: str = "cognitive-core-engine") -> None:
     """Initialise tracing providers if OpenTelemetry is available."""
-    if trace is None:  # pragma: no cover - graceful degradation
+
+    if trace is None:  # pragma: no cover - graceful degradation when OTel missing
         return
+
+    sdk_trace_spec = importlib.util.find_spec("opentelemetry.sdk.trace")
+    resource_spec = importlib.util.find_spec("opentelemetry.sdk.resources")
+    exporter_spec = importlib.util.find_spec("opentelemetry.sdk.trace.export")
+    if sdk_trace_spec is None or resource_spec is None or exporter_spec is None:
+        return
+
+    from opentelemetry.sdk.resources import SERVICE_NAME, Resource  # type: ignore
+    from opentelemetry.sdk.trace import TracerProvider  # type: ignore
+    from opentelemetry.sdk.trace.export import (  # type: ignore
+        BatchSpanProcessor,
+        ConsoleSpanExporter,
+    )
+
     resource = Resource(attributes={SERVICE_NAME: service_name})
     provider = TracerProvider(resource=resource)
     provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
-    trace.set_tracer_provider(provider)
+    try:
+        trace.set_tracer_provider(provider)
+    except RuntimeError:  # pragma: no cover - provider already configured
+        return
+
+
+def _observe_latency(route_name: str, elapsed: float) -> None:
+    REQUEST_LATENCY.labels(route=route_name).observe(elapsed)
 
 
 def instrument_route(route_name: str):
     """Decorator to time requests and create trace spans."""
-    def decorator(func):
+
+    def decorator(func: Callable[..., _T]):
         if asyncio.iscoroutinefunction(func):
+
             @wraps(func)
-            async def async_wrapper(*args, **kwargs):
+            async def async_wrapper(*args: Any, **kwargs: Any):
                 tracer = trace.get_tracer(__name__) if trace else None
-                span_cm = tracer.start_as_current_span(route_name) if tracer else contextlib.nullcontext()
-                with span_cm:
-                    start = time.perf_counter()
-                    result = await func(*args, **kwargs)
-                    REQUEST_LATENCY.labels(route=route_name).observe(time.perf_counter() - start)
+                span_cm = (
+                    tracer.start_as_current_span(route_name) if tracer else contextlib.nullcontext()
+                )
+                start = time.perf_counter()
+                span = None
+                try:
+                    with span_cm as span:
+                        result = await func(*args, **kwargs)
+                except Exception as exc:
+                    if span is not None:
+                        span.record_exception(exc)
+                        if Status is not None and StatusCode is not None:
+                            span.set_status(Status(StatusCode.ERROR, str(exc)))
+                    _observe_latency(route_name, time.perf_counter() - start)
+                    raise
+                else:
+                    _observe_latency(route_name, time.perf_counter() - start)
                     return result
 
             return async_wrapper
-        else:
-            @wraps(func)
-            def sync_wrapper(*args, **kwargs):
-                tracer = trace.get_tracer(__name__) if trace else None
-                span_cm = tracer.start_as_current_span(route_name) if tracer else contextlib.nullcontext()
-                with span_cm:
-                    start = time.perf_counter()
-                    result = func(*args, **kwargs)
-                    REQUEST_LATENCY.labels(route=route_name).observe(time.perf_counter() - start)
-                    return result
 
-            return sync_wrapper
+        @wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any):
+            tracer = trace.get_tracer(__name__) if trace else None
+            span_cm = (
+                tracer.start_as_current_span(route_name) if tracer else contextlib.nullcontext()
+            )
+            start = time.perf_counter()
+            span = None
+            try:
+                with span_cm as span:
+                    result = func(*args, **kwargs)
+            except Exception as exc:
+                if span is not None:
+                    span.record_exception(exc)
+                    if Status is not None and StatusCode is not None:
+                        span.set_status(Status(StatusCode.ERROR, str(exc)))
+                _observe_latency(route_name, time.perf_counter() - start)
+                raise
+            else:
+                _observe_latency(route_name, time.perf_counter() - start)
+                return result
+
+        return sync_wrapper
 
     return decorator
 
 
 def record_llm_tokens(route_name: str, tokens: int) -> None:
     """Record the number of tokens processed by an endpoint."""
+
     LLM_TOKENS.labels(route=route_name).inc(tokens)
+
+
+def _extract_route(request: Request) -> str:
+    candidate: Any = request.scope.get("route")
+    if candidate is not None:
+        path = getattr(candidate, "path", None) or getattr(candidate, "name", None)
+        if path:
+            return str(path)
+    return str(request.url.path)
+
+
+class ObservabilityMiddleware(BaseHTTPMiddleware):
+    """Collect Prometheus metrics and correlate logs with request metadata."""
+
+    def __init__(self, app):
+        super().__init__(app)
+        self._tracer = trace.get_tracer(__name__) if trace else None
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Any]]):
+        method = request.method
+        route = _extract_route(request)
+        client_ip = request.client.host if request.client else None
+        request_id = uuid.uuid4().hex
+        context_token = bind_log_context(
+            request_id=request_id,
+            http_method=method,
+            http_route=route,
+            client_ip=client_ip,
+        )
+        status_token: Token[dict[str, Any]] | None = None
+        status_code = 500
+        start = time.perf_counter()
+        span_cm = (
+            self._tracer.start_as_current_span(f"{method} {route}")
+            if self._tracer
+            else contextlib.nullcontext()
+        )
+        span = None
+        try:
+            with span_cm as span:
+                if span is not None:
+                    span.set_attribute("http.method", method)
+                    span.set_attribute("http.route", route)
+                    span.set_attribute("http.target", str(request.url))
+                    if client_ip:
+                        span.set_attribute("http.client_ip", client_ip)
+                response = await call_next(request)
+                status_code = getattr(response, "status_code", 200)
+        except Exception as exc:
+            if span is not None:
+                span.record_exception(exc)
+                if Status is not None and StatusCode is not None:
+                    span.set_status(Status(StatusCode.ERROR, str(exc)))
+            status_code = 500
+            status_token = bind_log_context(http_status=str(status_code))
+            raise
+        else:
+            status_token = bind_log_context(http_status=str(status_code))
+            return response
+        finally:
+            elapsed = time.perf_counter() - start
+            labels = {
+                "method": method,
+                "route": route,
+                "status": str(status_code),
+            }
+            HTTP_REQUEST_DURATION.labels(**labels).observe(elapsed)
+            HTTP_REQUESTS.labels(**labels).inc()
+            log_level = logging.WARNING if status_code >= 400 else logging.INFO
+            logger.log(
+                log_level,
+                "request.completed",
+                extra={
+                    "duration_ms": round(elapsed * 1000, 3),
+                    "status_code": status_code,
+                },
+            )
+            if status_token is not None:
+                reset_log_context(status_token)
+            reset_log_context(context_token)
+
+
+__all__ = [
+    "HTTP_REQUESTS",
+    "HTTP_REQUEST_DURATION",
+    "LLM_TOKENS",
+    "ObservabilityMiddleware",
+    "REQUEST_LATENCY",
+    "instrument_route",
+    "record_llm_tokens",
+    "setup_telemetry",
+]


### PR DESCRIPTION
## Summary
- configure structured JSON logging with contextual request correlation and expose a configurable log level
- add observability middleware that records Prometheus metrics, wraps FastAPI endpoints, and keeps CLI telemetry consistent
- extend README and operations documentation with deployment/update/incident procedures and note the new telemetry tooling

## Testing
- pip install -e '.[api,test,dev]' *(fails: proxy returned 403 for setuptools)*
- ruff check src/cognitive_core/utils/logging.py src/cognitive_core/utils/telemetry.py src/cognitive_core/api/main.py src/cognitive_core/cli.py src/cognitive_core/config/settings.py
- pytest *(fails: missing optional dependency 'alembic')*
- pytest tests/api/test_root.py

------
https://chatgpt.com/codex/tasks/task_e_68c929abc4b48329a0074da61385b05a