### PR TITLE
Validate async OpenAI base URL and add test

### DIFF
--- a/src/cognitive_core/llm/provider_async.py
+++ b/src/cognitive_core/llm/provider_async.py
@@ -1,24 +1,46 @@
 from __future__ import annotations
 
 import os
+from urllib.parse import urlparse, urlunparse
 
 try:
     import httpx
 except Exception:
     httpx = None
 
+from .provider import OpenAIAdapter
+
 
 class OpenAIAsyncAdapter:
     name = "openai-async"
+
+    _ALLOWED_API_HOSTS = OpenAIAdapter._ALLOWED_API_HOSTS
 
     def __init__(self, key: str | None = None, model: str = "gpt-4o-mini"):
         self.key = key or os.environ.get("OPENAI_API_KEY")
         self.model = model
 
+    @classmethod
+    def _validate_and_normalize_api_base(cls, base: str) -> str:
+        parsed = urlparse(base)
+
+        if parsed.scheme.lower() != "https" or not parsed.netloc or not parsed.hostname:
+            raise RuntimeError("OPENAI_API_BASE must be an https URL with a valid hostname.")
+
+        hostname = parsed.hostname.lower()
+        allowed_hosts = {host.lower() for host in cls._ALLOWED_API_HOSTS}
+        if hostname not in allowed_hosts:
+            raise RuntimeError("OPENAI_API_BASE hostname is not allowed.")
+
+        sanitized = urlunparse(("https", parsed.netloc, parsed.path or "", "", "", "")).rstrip("/")
+        return sanitized or f"https://{parsed.netloc}"
+
     async def run(self, prompt: str, **kwargs) -> dict:
         if not self.key:
             raise RuntimeError("OpenAIAsyncAdapter requires OPENAI_API_KEY in environment.")
-        base = os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1")
+        base = self._validate_and_normalize_api_base(
+            os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1")
+        )
         url = f"{base}/chat/completions"
         payload = {"model": self.model, "messages": [{"role": "user", "content": prompt}]}
         headers = {"Authorization": f"Bearer {self.key}", "Content-Type": "application/json"}

--- a/tests/unit/test_llm_provider_async.py
+++ b/tests/unit/test_llm_provider_async.py
@@ -1,0 +1,15 @@
+import asyncio
+
+import pytest
+
+from cognitive_core.llm.provider_async import OpenAIAsyncAdapter
+
+
+def test_openai_async_adapter_rejects_unapproved_api_base(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_API_BASE", "https://evil.example.com/v1")
+
+    adapter = OpenAIAsyncAdapter()
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(adapter.run("hello"))


### PR DESCRIPTION
## Summary
- validate and normalize the OPENAI_API_BASE for the async adapter using the shared allowed-host whitelist
- ensure request URLs are built from the sanitized base to prevent malicious overrides
- add a unit test asserting the async adapter rejects disallowed API hosts

## Testing
- pytest tests/unit/test_llm_provider_async.py tests/unit/test_llm_provider_cost.py

------
https://chatgpt.com/codex/tasks/task_e_68c942031cf88329b6307a9d089ad24a