### PR TITLE
Add configurable security headers

### DIFF
--- a/src/cognitive_core/api/main.py
+++ b/src/cognitive_core/api/main.py
@@ -27,6 +27,9 @@ app.add_middleware(
 app.add_middleware(RateLimitMiddleware)
 app.add_middleware(
     SecureHeadersMiddleware,
+    referrer_policy=settings.security_referrer_policy,
+    permissions_policy=settings.security_permissions_policy,
+    content_security_policy=settings.security_content_security_policy,
 )
 # Register application routers
 app.include_router(health.router, prefix=settings.api_prefix, tags=["health"])

--- a/src/cognitive_core/api/security.py
+++ b/src/cognitive_core/api/security.py
@@ -21,11 +21,17 @@ class SecureHeadersMiddleware(BaseHTTPMiddleware):
         strict_transport_security: str = "max-age=63072000; includeSubDomains; preload",
         x_frame_options: str = "DENY",
         x_content_type_options: str = "nosniff",
+        referrer_policy: str = "strict-origin-when-cross-origin",
+        permissions_policy: str = "interest-cohort=()",
+        content_security_policy: str | None = "default-src 'self'",
     ) -> None:
         super().__init__(app)
         self._strict_transport_security = strict_transport_security
         self._x_frame_options = x_frame_options
         self._x_content_type_options = x_content_type_options
+        self._referrer_policy = referrer_policy
+        self._permissions_policy = permissions_policy
+        self._content_security_policy = content_security_policy
 
     async def dispatch(self, request: Request, call_next: CallNext) -> Response:
         response = await call_next(request)
@@ -39,6 +45,14 @@ class SecureHeadersMiddleware(BaseHTTPMiddleware):
         if self._x_content_type_options:
             response.headers.setdefault(
                 "X-Content-Type-Options", self._x_content_type_options
+            )
+        if self._referrer_policy:
+            response.headers.setdefault("Referrer-Policy", self._referrer_policy)
+        if self._permissions_policy:
+            response.headers.setdefault("Permissions-Policy", self._permissions_policy)
+        if self._content_security_policy:
+            response.headers.setdefault(
+                "Content-Security-Policy", self._content_security_policy
             )
 
         return response

--- a/src/cognitive_core/config/settings.py
+++ b/src/cognitive_core/config/settings.py
@@ -33,6 +33,18 @@ class Settings(BaseSettings):
         default_factory=list,
         description="List of allowed CORS origins for the public API.",
     )
+    security_referrer_policy: str = Field(
+        default="strict-origin-when-cross-origin",
+        description="Value for the Referrer-Policy header applied to all responses.",
+    )
+    security_permissions_policy: str = Field(
+        default="interest-cohort=()",
+        description="Value for the Permissions-Policy header applied to all responses.",
+    )
+    security_content_security_policy: str | None = Field(
+        default="default-src 'self'",
+        description="Value for the Content-Security-Policy header applied to all responses.",
+    )
 
     @field_validator("allowed_origins", mode="before")
     @classmethod

--- a/tests/api/test_root.py
+++ b/tests/api/test_root.py
@@ -33,3 +33,8 @@ def test_security_headers_present():
     )
     assert r.headers["X-Frame-Options"] == "DENY"
     assert r.headers["X-Content-Type-Options"] == "nosniff"
+    assert (
+        r.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    )
+    assert r.headers["Permissions-Policy"] == "interest-cohort=()"
+    assert r.headers["Content-Security-Policy"] == "default-src 'self'"


### PR DESCRIPTION
## Summary
- extend the security middleware to add Referrer-Policy, Permissions-Policy, and Content-Security-Policy headers
- expose configurable settings for the new headers and wire them into the FastAPI application
- update the root endpoint test to assert the presence of the new security headers

## Testing
- pytest tests/api/test_root.py

------
https://chatgpt.com/codex/tasks/task_e_68c94203178883299091ae3981063434