### PR TITLE
Use subprocess.run in validation script

### DIFF
--- a/tools/validate.py
+++ b/tools/validate.py
@@ -1,5 +1,16 @@
-import subprocess as sp
+import subprocess
 import sys
 
-cmds = ["ruff check .", "black --check .", "isort --check-only .", "pytest -q"]
-sys.exit(sum(sp.call(c, shell=True) for c in cmds))
+COMMANDS = [
+    ["ruff", "check", "."],
+    ["black", "--check", "."],
+    ["isort", "--check-only", "."],
+    ["pytest", "-q"],
+]
+
+for command in COMMANDS:
+    result = subprocess.run(command)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+sys.exit(0)


### PR DESCRIPTION
## Summary
- replace shell commands with `subprocess.run` argument lists in `tools/validate.py`
- exit immediately when a validation command fails to highlight the first error

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c94203d9f0832981ba3e1e06379b69