### PR TITLE
Add configurable security headers middleware options

### DIFF
--- a/src/cognitive_core/api/security.py
+++ b/src/cognitive_core/api/security.py
@@ -18,14 +18,20 @@ class SecureHeadersMiddleware(BaseHTTPMiddleware):
         self,
         app: ASGIApp,
         *,
-        strict_transport_security: str = "max-age=63072000; includeSubDomains; preload",
-        x_frame_options: str = "DENY",
-        x_content_type_options: str = "nosniff",
+        strict_transport_security: str | None = "max-age=63072000; includeSubDomains; preload",
+        x_frame_options: str | None = "DENY",
+        x_content_type_options: str | None = "nosniff",
+        referrer_policy: str | None = "strict-origin-when-cross-origin",
+        permissions_policy: str | None = "interest-cohort=()",
+        content_security_policy: str | None = None,
     ) -> None:
         super().__init__(app)
         self._strict_transport_security = strict_transport_security
         self._x_frame_options = x_frame_options
         self._x_content_type_options = x_content_type_options
+        self._referrer_policy = referrer_policy
+        self._permissions_policy = permissions_policy
+        self._content_security_policy = content_security_policy
 
     async def dispatch(self, request: Request, call_next: CallNext) -> Response:
         response = await call_next(request)
@@ -39,6 +45,14 @@ class SecureHeadersMiddleware(BaseHTTPMiddleware):
         if self._x_content_type_options:
             response.headers.setdefault(
                 "X-Content-Type-Options", self._x_content_type_options
+            )
+        if self._referrer_policy:
+            response.headers.setdefault("Referrer-Policy", self._referrer_policy)
+        if self._permissions_policy:
+            response.headers.setdefault("Permissions-Policy", self._permissions_policy)
+        if self._content_security_policy:
+            response.headers.setdefault(
+                "Content-Security-Policy", self._content_security_policy
             )
 
         return response

--- a/tests/security/test_headers.py
+++ b/tests/security/test_headers.py
@@ -1,11 +1,45 @@
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cognitive_core.api.auth import verify_api_key
+from cognitive_core.api.security import SecureHeadersMiddleware
 
 
 @pytest.mark.integration
 def test_default_security_headers(api_client):
-    r = api_client.get("/api/health")
+    api_client.app.dependency_overrides[verify_api_key] = lambda: None
+    try:
+        r = api_client.get("/api/health")
+    finally:
+        api_client.app.dependency_overrides.pop(verify_api_key, None)
     assert r.status_code == 200
     assert "content-type" in {k.lower() for k in r.headers.keys()}
     csp = r.headers.get("content-security-policy")  # may be None
     acao = r.headers.get("access-control-allow-origin", "")
     assert "*" not in acao or "null" not in acao
+    assert r.headers.get("referrer-policy") == "strict-origin-when-cross-origin"
+    assert r.headers.get("permissions-policy") == "interest-cohort=()"
+    assert csp is None
+
+
+def test_custom_security_headers():
+    app = FastAPI()
+    app.add_middleware(
+        SecureHeadersMiddleware,
+        referrer_policy="no-referrer",
+        permissions_policy="geolocation=(self)",
+        content_security_policy="default-src 'self'",
+    )
+
+    @app.get("/")
+    def _root() -> dict[str, str]:
+        return {"status": "ok"}
+
+    client = TestClient(app)
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.headers["Referrer-Policy"] == "no-referrer"
+    assert response.headers["Permissions-Policy"] == "geolocation=(self)"
+    assert response.headers["Content-Security-Policy"] == "default-src 'self'"


### PR DESCRIPTION
## Summary
- add configurable Referrer-Policy, Permissions-Policy, and optional Content-Security-Policy support to SecureHeadersMiddleware
- extend security header tests to cover middleware defaults and custom configurations

## Testing
- pytest tests/security/test_headers.py

------
https://chatgpt.com/codex/tasks/task_e_68c94c2d51c88329a65d33e4a95cfc4d