### PR TITLE
Improve validation command execution

### DIFF
--- a/tools/validate.py
+++ b/tools/validate.py
@@ -1,5 +1,26 @@
 import subprocess as sp
 import sys
 
-cmds = ["ruff check .", "black --check .", "isort --check-only .", "pytest -q"]
-sys.exit(sum(sp.call(c, shell=True) for c in cmds))
+COMMANDS = [
+    ["ruff", "check", "."],
+    ["black", "--check", "."],
+    ["isort", "--check-only", "."],
+    ["pytest", "-q"],
+]
+
+
+def main() -> int:
+    for command in COMMANDS:
+        try:
+            sp.run(command, check=True)
+        except sp.CalledProcessError as exc:
+            print(
+                f"Команда {command} завершилася з кодом {exc.returncode}",
+                file=sys.stderr,
+            )
+            return exc.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- replace the validation command strings with explicit argument lists
- execute each tool with `subprocess.run(..., check=True)` and stop on the first failure while reporting the exit code

## Testing
- python -m compileall tools/validate.py

------
https://chatgpt.com/codex/tasks/task_e_68c94c2ecc2c832987a902a13dd4d2de