### PR TITLE
Document lock refresh workflow and enforce in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,7 @@ jobs:
               echo 'requirements.lock is a placeholder. Regenerate it with pip-compile before merging.' >&2
               exit 1
             fi
-            pip-compile pyproject.toml \
-              --extra api \
-              --extra test \
-              --extra dev \
+            pip-compile requirements.txt \
               --generate-hashes \
               --output-file requirements.lock.new
             if ! diff -u requirements.lock requirements.lock.new >/tmp/lock.diff; then

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -37,25 +37,20 @@ Steps:
 
 ## Dependency management
 
-Use [`pip-tools`](https://github.com/jazzband/pip-tools) to keep dependency pins and the lock file consistent with `pyproject.toml`.
+Use [`pip-tools`](https://github.com/jazzband/pip-tools) to keep dependency pins and the lock file consistent with `requirements.txt`.
 
-1. Edit `pyproject.toml` to add or upgrade dependencies. Prefer ranges with upper bounds so updates remain controlled.
-2. Install tooling (once per environment):
+1. Edit `pyproject.toml` to add or upgrade dependencies (and `requirements.txt` if new extras are exposed). Prefer ranges with upper bounds so updates remain controlled.
+2. Ensure you are in an environment with internet access and install the tooling (once per environment):
    ```bash
    python -m pip install --upgrade pip pip-tools
    ```
-3. Recompile the lock file with hashes for all extras that we ship:
+3. Recompile the lock file with hashes for everything listed in `requirements.txt`:
    ```bash
-   pip-compile pyproject.toml \
-     --extra api \
-     --extra test \
-     --extra dev \
-     --generate-hashes \
-     --output-file requirements.lock
+   pip-compile requirements.txt --generate-hashes --output-file requirements.lock
    ```
-4. Review the diff, run the usual test suite (`pytest`) and commit both `pyproject.toml` and `requirements.lock` together.
+4. Review the diff, run the usual test suite (`pytest`) and commit `pyproject.toml`, `requirements.txt`, and `requirements.lock` together.
 
-The CI workflow reruns `pip-compile` and fails if the generated lock file does not match the committed version, so make sure to regenerate it before opening a pull request.
+The CI workflow reruns the same `pip-compile` command and fails if the generated lock file does not match the committed version, so make sure to regenerate it before opening a pull request.
 
 ## Observability
 ```mermaid

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,7 +1,7 @@
 # requirements.lock placeholder
 #
 # This repository is maintained in an offline environment, so generating a
-# fully hashed lock file with `pip-compile --generate-hashes` is not possible
+# fully hashed lock file with `pip-compile requirements.txt --generate-hashes`
 # here. Follow the instructions in docs/operations.md to regenerate this file
 # with the correct hashes once network access is available.
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,24 @@
--e .[dev]
+# Core runtime dependencies
+pydantic>=2.7,<3.0
+typing-extensions>=4.8,<5.0
+fastapi>=0.111,<0.120
+uvicorn>=0.29,<0.36
+httpx>=0.25,<0.29
+
+# Observability
+prometheus-client>=0.20,<0.21
+opentelemetry-sdk>=1.24,<2.0
+
+# Testing stack
+pytest>=7.4,<8.0
+pytest-cov>=4.1,<5.0
+hypothesis>=6.99,<7.0
+pyyaml>=6.0.1,<7.0
+alembic>=1.13,<2.0
+
+# Developer tools
+ruff>=0.5.0,<0.6
+black>=24.4,<25.0
+isort>=5.13,<6.0
+mypy>=1.8,<2.0
+types-requests>=2.31.0.6,<3.0


### PR DESCRIPTION
## Summary
- refresh the dependency management section to document the new pip-compile workflow against requirements.txt
- expand requirements.txt so it lists the project and tooling dependencies that should be locked
- adjust the CI lock-file check to regenerate requirements.lock from requirements.txt with hashes

## Testing
- not run (documentation and CI configuration updates only)

## Additional Notes
- pip-tools could not be installed in this environment because outbound network access is blocked by the proxy, so the lock file remains the documented placeholder

------
https://chatgpt.com/codex/tasks/task_e_68c94c2f83b483298f1e3a9a20f3f996