### PR TITLE
Handle missing agent roles in pipelines API

### DIFF
--- a/src/cognitive_core/api/routers/pipelines.py
+++ b/src/cognitive_core/api/routers/pipelines.py
@@ -64,6 +64,9 @@ def run_pipeline(req: RunRequest = Body(...)):
 @router.post("/pipelines/aots_debate")
 @instrument_route("aots_debate")
 def aots_debate(req: DebateRequest) -> DebateRound:
-    round = agents_router.run(req.prompt, req.roles, concurrent=req.concurrent)
+    try:
+        round = agents_router.run(req.prompt, req.roles, concurrent=req.concurrent)
+    except (ValueError, FileNotFoundError) as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     record_llm_tokens("aots_debate", len(round.responses))
     return round

--- a/src/cognitive_core/core/agents_router.py
+++ b/src/cognitive_core/core/agents_router.py
@@ -41,6 +41,9 @@ class AgentsRouter:
         if not path.is_relative_to(self.config_dir):
             raise ValueError(f"Invalid role name: {name}")
 
+        if not path.is_file():
+            raise ValueError(f"Role definition '{name}' not found in agents configuration directory.")
+
         with path.open() as f:
             if yaml:
                 data = yaml.safe_load(f) or {}

--- a/tests/test_pipelines_api.py
+++ b/tests/test_pipelines_api.py
@@ -8,3 +8,14 @@ def test_run_pipeline(api_client):
     data = resp.json()
     assert data["status"] == "completed"
     assert data["artifacts"] == ["result"]
+
+
+def test_aots_debate_missing_role_returns_404(api_client):
+    resp = api_client.post(
+        "/api/pipelines/aots_debate",
+        json={"prompt": "test", "roles": ["does-not-exist"]},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == (
+        "Role definition 'does-not-exist' not found in agents configuration directory."
+    )


### PR DESCRIPTION
## Summary
- fail fast when an agent role configuration file is missing
- return an HTTP 404 from the AOTS debate endpoint when requested roles are absent
- cover the new behavior with an API test for the debate pipeline

## Testing
- PYTHONPATH=src pytest tests/test_pipelines_api.py

------
https://chatgpt.com/codex/tasks/task_e_68c9b6c708c88329a25552365dc1f07e