### PR TITLE
Ensure Makefile setup installs all extras

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@
 setup:
 	@if [ -f requirements.txt ] || [ -f pyproject.toml ]; then \
 	python -m pip install -U pip; \
-	if [ -f pyproject.toml ]; then pip install -e .[dev]; elif [ -f requirements.txt ]; then pip install -r requirements.txt; fi; \
+	if [ -f pyproject.toml ]; then pip install -e ".[api,test,dev]"; \
+	elif [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; \
+	elif [ -f requirements.txt ]; then pip install -r requirements.txt; \
+	fi; \
 	fi
 	@if [ -f package.json ]; then npm install; fi
 	@if [ -f go.mod ]; then go mod download; fi


### PR DESCRIPTION
## Summary
- ensure the Makefile setup target installs the api, test, and dev extras when a pyproject is present
- fall back to requirements-dev.txt when pyproject.toml is absent so both paths pull the same optional dependencies

## Testing
- make setup *(fails: pip cannot reach proxy to download build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ca11778e988329879b6d74cc1a3531