### PR TITLE
Handle Redis limiter outages gracefully

### DIFF
--- a/src/cognitive_core/llm/provider_wrapper.py
+++ b/src/cognitive_core/llm/provider_wrapper.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
+import logging
 import os
 
+from ..api.rate_limit import InMemoryBucketLimiter
+from ..config import settings
+from ..rate_limiter import (
+    RateLimiterUnavailableError,
+    RedisBucketLimiter,
+    RedisCostTracker,
+)
 from .provider import LLMProvider, MockProvider, OpenAIAdapter
+
+
+logger = logging.getLogger(__name__)
 
 
 class ProviderWrapper:
@@ -14,20 +25,40 @@ class ProviderWrapper:
         self.redis_url = os.environ.get("REDIS_URL")
         self.limiter = None
         self.tracker = None
+        self._limiter_kwargs = {
+            "capacity": settings.rate_limit_burst,
+            "refill_per_sec": settings.rate_limit_rps,
+        }
         if self.redis_url:
             try:
-                from ..rate_limiter import RedisBucketLimiter, RedisCostTracker
-
-                self.limiter = RedisBucketLimiter(redis_url=self.redis_url, bucket_key="cce_bucket")
+                self.limiter = RedisBucketLimiter(
+                    redis_url=self.redis_url,
+                    bucket_key="cce_bucket",
+                    capacity=self._limiter_kwargs["capacity"],
+                    refill_per_sec=self._limiter_kwargs["refill_per_sec"],
+                )
                 self.tracker = RedisCostTracker(redis_url=self.redis_url)
-            except Exception:
-                self.limiter = None
+            except Exception as exc:
+                logger.warning(
+                    "Redis services unavailable (%s); falling back to in-memory limiter.",
+                    exc,
+                )
+                self._ensure_in_memory_limiter()
                 self.tracker = None
 
     def run(self, prompt: str, client_id: str = "default", **kwargs) -> dict:
         est_tokens = max(1, len(prompt) // 4)
         if self.limiter:
-            ok = self.limiter.allow(client_id, needed=1.0)
+            try:
+                ok = self.limiter.allow(client_id, needed=1.0)
+            except RateLimiterUnavailableError as exc:
+                logger.warning(
+                    "Redis rate limiter unavailable for provider calls (%s); "
+                    "switching to in-memory limiter.",
+                    exc,
+                )
+                self._ensure_in_memory_limiter()
+                ok = self.limiter.allow(client_id, needed=1.0) if self.limiter else True
             if not ok:
                 return {"error": "rate_limited", "_cost_usd": 0.0}
         self.calls += 1
@@ -45,3 +76,9 @@ class ProviderWrapper:
             {"_est_tokens": est_tokens, "_total_calls": self.calls, "_cost_accum": self.cost_usd}
         )
         return out
+
+    def _ensure_in_memory_limiter(self) -> None:
+        if isinstance(self.limiter, InMemoryBucketLimiter):
+            return
+        self.limiter = InMemoryBucketLimiter(**self._limiter_kwargs)
+        self.tracker = None


### PR DESCRIPTION
## Summary
- log Redis limiter backend errors and raise a dedicated transient exception
- teach the FastAPI rate limit middleware to fall back to the in-memory limiter when Redis fails
- update the provider wrapper and add a regression test covering Redis outages

## Testing
- PYTHONPATH=src pytest tests/security/test_rate_limit.py

------
https://chatgpt.com/codex/tasks/task_e_68ca1d621de883299bb9a09cb786e9c2