### PR TITLE
Update healthcheck to respect API prefix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,4 @@ USER ${APP_USER}
 EXPOSE 8000
 CMD ["uvicorn", "cognitive_core.api.main:app", "--host", "0.0.0.0", "--port", "8000"]
 
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD python -c "import urllib.request as u; u.urlopen('http://127.0.0.1:8000/health')" || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD python -c "import os, urllib.request as u; raw=os.environ.get('COG_API_PREFIX', '/api'); prefix='/' + raw.strip('/') if raw else ''; prefix='' if prefix == '/' else prefix; u.urlopen(f'http://127.0.0.1:8000{prefix}/health')" || exit 1


### PR DESCRIPTION
## Summary
- update the Docker healthcheck to call the FastAPI health endpoint using the configured API prefix

## Testing
- not run (docker command not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68ca288d40688329b460bd06bcd7ece5