### PR TITLE
chore: expose cog settings in systemd unit

### DIFF
--- a/deployment/cognitive_core.service
+++ b/deployment/cognitive_core.service
@@ -9,7 +9,11 @@ Group=www-data
 WorkingDirectory=/opt/cognitive-core
 Environment=DATABASE_URL=postgresql+psycopg2://cce:cce@localhost:5432/cce
 Environment=REDIS_URL=redis://localhost:6379/0
-Environment=API_KEY=changeme
+Environment=COG_API_KEY=changeme
+Environment=COG_APP_NAME=Cognitive Core Engine
+Environment=COG_API_PREFIX=/api
+Environment=COG_RATE_LIMIT_RPS=5
+Environment=COG_RATE_LIMIT_BURST=10
 ExecStart=/opt/cognitive-core/.venv/bin/uvicorn cognitive_core.api.main:app --host 0.0.0.0 --port 8000
 Restart=on-failure
 RestartSec=5s


### PR DESCRIPTION
## Summary
- switch the systemd service to set the namespaced COG_API_KEY expected by the app
- expose additional COG_* settings that operators commonly tune when deploying the API

## Testing
- PYTHONPATH=src python - <<'PY'
from cognitive_core.api import rate_limit
rate_limit.RedisBucketLimiter = None
from cognitive_core.config import settings
settings.api_key = "changeme"
from fastapi.testclient import TestClient
from cognitive_core.api.main import app
with TestClient(app) as client:
    resp = client.get("/api/health", headers={"X-API-Key": "changeme"})
    print(resp.status_code, resp.json())
PY

------
https://chatgpt.com/codex/tasks/task_e_68ca4e13d92083299945b27b2fbb4131