### PR TITLE
Add pydantic-settings dependency and cover stub environment loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.7,<3.0",
+    "pydantic-settings>=2.0,<3.0",
     "typing-extensions>=4.8,<5.0",
     "fastapi>=0.111,<0.120",
     "uvicorn>=0.29,<0.36",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Core runtime dependencies
 pydantic>=2.7,<3.0
+pydantic-settings>=2.0,<3.0
 typing-extensions>=4.8,<5.0
 fastapi>=0.111,<0.120
 uvicorn>=0.29,<0.36

--- a/src/pydantic_settings/__init__.py
+++ b/src/pydantic_settings/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import Any, Callable
 
 try:  # pragma: no cover - optional dependency hints
@@ -16,13 +17,16 @@ class BaseSettings:
     """Minimal replacement for :class:`pydantic_settings.BaseSettings`.
 
     This stub implements only the behaviour required by the test-suite: mapping
-    class attributes with defaults to instance attributes on construction.
-    Environment loading and validation are intentionally omitted.
+    class attributes with defaults to instance attributes on construction and
+    reading overrides from environment variables respecting ``model_config``
+    options such as ``env_prefix``. Validation and type coercion are still
+    intentionally omitted.
     """
 
     model_config: SettingsConfigDict
 
     def __init__(self, **values: Any) -> None:
+        env_prefix = self._resolve_env_prefix()
         for name, attr in self.__class__.__dict__.items():
             if name.startswith("_") or name == "model_config":
                 continue
@@ -31,7 +35,9 @@ class BaseSettings:
             if name in values:
                 value = values[name]
             else:
-                value = self._resolve_default(attr)
+                value = self._resolve_env_value(env_prefix, name)
+                if value is None:
+                    value = self._resolve_default(attr)
             setattr(self, name, value)
 
     @staticmethod
@@ -50,6 +56,23 @@ class BaseSettings:
 
         default = getattr(attr, "default", attr)
         return default
+
+    @classmethod
+    def _resolve_env_prefix(cls) -> str:
+        config = getattr(cls, "model_config", None)
+        if isinstance(config, dict):
+            raw_prefix = config.get("env_prefix", "")
+            if raw_prefix is None:
+                return ""
+            return str(raw_prefix)
+        return ""
+
+    @staticmethod
+    def _resolve_env_value(env_prefix: str, field_name: str) -> Any | None:
+        env_key = f"{env_prefix}{field_name}".upper()
+        if env_key in os.environ:
+            return os.environ[env_key]
+        return None
 
 
 __all__ = ["BaseSettings", "SettingsConfigDict"]

--- a/tests/config/test_settings_env_stub.py
+++ b/tests/config/test_settings_env_stub.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+
+def _load_module(module_name: str, file_path: Path, monkeypatch):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"Unable to load module {module_name} from {file_path}")
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_settings_reads_environment_when_third_party_missing(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[2]
+    stub_path = repo_root / "src" / "pydantic_settings" / "__init__.py"
+    settings_path = repo_root / "src" / "cognitive_core" / "config" / "settings.py"
+
+    stub_module = _load_module("pydantic_settings", stub_path, monkeypatch)
+
+    monkeypatch.setenv("COG_API_KEY", "env-secret")
+
+    settings_module = _load_module("tests.config._stubbed_settings", settings_path, monkeypatch)
+
+    settings = settings_module.Settings()
+
+    assert settings_module.BaseSettings is stub_module.BaseSettings
+    assert settings.api_key == "env-secret"
+
+    # Ensure the stub leaves unrelated environment variables untouched.
+    assert os.environ["COG_API_KEY"] == "env-secret"


### PR DESCRIPTION
## Summary
- add the pydantic-settings dependency to the project configuration and requirements lists
- extend the local fallback BaseSettings stub to load values from the environment when prefixed
- add a regression test that verifies Settings picks up COG_API_KEY using the stub implementation

## Testing
- PYTHONPATH=src pytest tests/config/test_settings_env_stub.py

------
https://chatgpt.com/codex/tasks/task_e_68cabfdd36f48329b59daf4a2dbdd96d