### PR TITLE
Configure MkDocs Material with Mermaid support

### DIFF
--- a/docs/javascripts/mermaid-init.js
+++ b/docs/javascripts/mermaid-init.js
@@ -1,0 +1,13 @@
+(function () {
+  function initializeMermaid() {
+    if (window.mermaid && typeof window.mermaid.initialize === "function") {
+      window.mermaid.initialize({ startOnLoad: true });
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initializeMermaid);
+  } else {
+    initializeMermaid();
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,19 @@
 site_name: cognitive-core-engine
+theme:
+  name: material
+markdown_extensions:
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 nav:
   - API: api.md
   - Architecture: architecture.md
   - Operations: operations.md
   - Plugins: plugins.md
+plugins:
+  - search
+  - mermaid2
+extra_javascript:
+  - javascripts/mermaid-init.js

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,12 @@ dev = [
     "mypy>=1.8,<2.0",
     "types-requests>=2.31.0.6,<3.0",
 ]
+docs = [
+    "mkdocs>=1.6,<2.0",
+    "mkdocs-material>=9.5,<10.0",
+    "pymdown-extensions>=10.8,<11.0",
+    "mkdocs-mermaid2-plugin>=1.1,<2.0",
+]
 
 [project.scripts]
 cogctl = "cognitive_core.cli:main"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
--e .[api,test,dev]
+-e .[api,test,dev,docs]
 fastapi>=0.111,<0.120
 httpx>=0.25,<0.29
 pytest>=7.4,<8.0


### PR DESCRIPTION
## Summary
- configure MkDocs to use the Material theme with Mermaid superfences support and plugin loading
- add a Mermaid initialization script to ensure diagrams render on page load
- declare documentation dependencies for MkDocs, Material, and Mermaid support

## Testing
- `pip install -r requirements-dev.txt` *(fails: environment cannot reach package index to download build dependencies)*
- `mkdocs serve` *(fails: mkdocs command not available because dependencies could not be installed in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd34fef088329a9068383e6dc36bf