### PR TITLE
Handle missing cogctl binary in math consistency tests

### DIFF
--- a/tests/test_math_consistency.py
+++ b/tests/test_math_consistency.py
@@ -9,7 +9,12 @@ from cognitive_core.app import services
 
 def _run_cli(args: str):
     for exe in ("cogctl", "python -m cognitive_core.cli"):
-        proc = subprocess.run(shlex.split(f"{exe} {args}"), capture_output=True, text=True)
+        try:
+            proc = subprocess.run(
+                shlex.split(f"{exe} {args}"), capture_output=True, text=True
+            )
+        except FileNotFoundError:
+            continue
         if proc.returncode == 0 and proc.stdout.strip():
             return json.loads(proc.stdout)
     pytest.skip("CLI not available")


### PR DESCRIPTION
## Summary
- wrap math consistency CLI runner in FileNotFoundError handling to fall back to the module entry point

## Testing
- PYTHONPATH=src python - <<'PY'
import cognitive_core.api.rate_limit as rl
rl.RedisBucketLimiter = None
import pytest
raise SystemExit(pytest.main(["-k", "test_math_consistency", "tests/test_math_consistency.py"]))
PY

------
https://chatgpt.com/codex/tasks/task_e_68cbf76a5a588329aebde1828de5a155