### PR TITLE
Refactor pipeline executor concurrency test

### DIFF
--- a/tests/test_pipeline_executor.py
+++ b/tests/test_pipeline_executor.py
@@ -1,5 +1,6 @@
 import asyncio
-import time
+import contextlib
+from unittest.mock import patch
 
 
 def test_pipeline_executor_runs_steps():
@@ -40,27 +41,83 @@ def test_execute_async_runs_steps_in_parallel_and_records_events():
     from cognitive_core.core.pipeline_executor import PipelineExecutor
     from cognitive_core.domain.pipelines import Artifact, Pipeline, Run
 
-    async def step_one():
-        await asyncio.sleep(0.2)
-        return Artifact(name="a", data=1)
+    async def _run() -> tuple[Run, list[tuple[str, str]]]:
+        class SleepController:
+            def __init__(self) -> None:
+                self.waiters: list[asyncio.Future] = []
+                self.ready = asyncio.Event()
 
-    async def step_two():
-        await asyncio.sleep(0.2)
-        return Artifact(name="b", data=2)
+            async def sleep(self, _: float) -> None:
+                loop = asyncio.get_running_loop()
+                waiter: asyncio.Future = loop.create_future()
+                self.waiters.append(waiter)
+                if len(self.waiters) >= 2:
+                    self.ready.set()
+                await waiter
 
-    async def _run() -> tuple[float, Run]:
-        pipeline = Pipeline(id="p2", name="AsyncTest", steps=[step_one, step_two])
-        start = time.time()
-        run = await PipelineExecutor().execute_async(pipeline)
-        duration = time.time() - start
-        return duration, run
+            def release_all(self) -> None:
+                for waiter in self.waiters:
+                    if not waiter.done():
+                        waiter.set_result(None)
 
-    duration, run = asyncio.run(_run())
+        sleep_controller = SleepController()
+        step_events: list[tuple[str, str]] = []
 
-    assert duration < 0.35
+        async def step_one():
+            step_events.append(("step_one", "start"))
+            await asyncio.sleep(0.2)
+            step_events.append(("step_one", "end"))
+            return Artifact(name="a", data=1)
+
+        async def step_two():
+            step_events.append(("step_two", "start"))
+            await asyncio.sleep(0.2)
+            step_events.append(("step_two", "end"))
+            return Artifact(name="b", data=2)
+
+        async def fake_sleep(delay: float) -> None:
+            await sleep_controller.sleep(delay)
+
+        with patch("asyncio.sleep", new=fake_sleep):
+            pipeline = Pipeline(id="p2", name="AsyncTest", steps=[step_one, step_two])
+            run_task = asyncio.create_task(PipelineExecutor().execute_async(pipeline))
+
+            try:
+                await asyncio.wait_for(sleep_controller.ready.wait(), timeout=1)
+            except asyncio.TimeoutError:
+                run_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await run_task
+                raise
+
+            assert len(step_events) == 2
+            assert {name for name, event_type in step_events} == {
+                "step_one",
+                "step_two",
+            }
+            assert all(event_type == "start" for _, event_type in step_events)
+
+            sleep_controller.release_all()
+            run = await run_task
+
+        return run, step_events
+
+    run, step_events = asyncio.run(_run())
+
     assert sorted(a.data for a in run.artifacts) == [1, 2]
     assert run.status == "completed"
     assert len(run.events) == 4
+    assert len(step_events) == 4
+
+    assert {event for event in step_events[:2]} == {
+        ("step_one", "start"),
+        ("step_two", "start"),
+    }
+    assert {event for event in step_events[2:]} == {
+        ("step_one", "end"),
+        ("step_two", "end"),
+    }
+    assert all(event_type == "end" for _, event_type in step_events[2:])
 
     for step in ["step_one", "step_two"]:
         start_event = next(e for e in run.events if e.step == step and e.type == "start")


### PR DESCRIPTION
## Summary
- stub out asyncio.sleep in the async pipeline executor test using a controllable SleepController to avoid real time delays
- record step start/end events and assert on their ordering to verify concurrency instead of relying on wall clock durations

## Testing
- PYTHONPATH=src pytest tests/test_pipeline_executor.py

------
https://chatgpt.com/codex/tasks/task_e_68cbf76b4618832991c98f41ba81280a