### PR TITLE
Improve dot API test diagnostics

### DIFF
--- a/tests/test_dot_api.py
+++ b/tests/test_dot_api.py
@@ -1,4 +1,5 @@
 def test_dot(api_client):
-    assert (
-        api_client.post("/api/dot", json={"a": [1, 2, 3], "b": [4, 5, 6]}).json()["result"] == 32.0
-    )
+    response = api_client.post("/api/dot", json={"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    assert response.status_code == 200
+    assert response.json()["result"] == 32.0


### PR DESCRIPTION
## Summary
- store the POST response in the dot API test
- assert the status code prior to checking the JSON payload
- leave the JSON expectation unchanged for clarity

## Testing
- `PYTHONPATH=src pytest tests/test_dot_api.py` *(fails: redis package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cc10fa2c7083298d630d316bef4333