### PR TITLE
Add status code assertions to health API tests

### DIFF
--- a/tests/test_health_api.py
+++ b/tests/test_health_api.py
@@ -1,16 +1,24 @@
 def test_healthz(api_client):
-    assert api_client.get("/api/healthz").json()["status"] == "ok"
+    resp = api_client.get("/api/healthz")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
 
 
 def test_livez(api_client):
-    assert api_client.get("/api/livez").json()["status"] == "ok"
+    resp = api_client.get("/api/livez")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
 
 
 def test_readyz(api_client):
-    assert api_client.get("/api/readyz").json()["status"] == "ok"
+    resp = api_client.get("/api/readyz")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
 
 
 def test_info(api_client):
-    data = api_client.get("/api/v1/info").json()
+    resp = api_client.get("/api/v1/info")
+    assert resp.status_code == 200
+    data = resp.json()
     assert data["name"]
     assert data["version"]


### PR DESCRIPTION
## Summary
- add explicit status code assertions in the health endpoint tests before parsing JSON responses

## Testing
- ✅ `PYTHONPATH=src pytest tests/test_health_api.py` *(fails: AttributeError: 'RateLimitMiddleware' object has no attribute 'limiter' due to missing redis dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68cc10fc5fec8329bbc12e06a62ccca8