### PR TITLE
Adjust solve2x2 API test response handling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ except Exception:
 
 from cognitive_core import config
 from cognitive_core.api import auth
+from cognitive_core.api import rate_limit
 from cognitive_core.api.main import app
 
 @pytest.fixture(scope="function")
@@ -18,6 +19,15 @@ def api_client(monkeypatch):
     monkeypatch.setenv("COG_API_KEY", api_key)
     config.settings = config.Settings(api_key=api_key)
     auth.settings = config.settings
+    monkeypatch.setattr(
+        rate_limit, "RedisBucketLimiter", None, raising=False
+    )
+    monkeypatch.setattr(
+        rate_limit,
+        "_redis_import_error",
+        RuntimeError("redis package unavailable"),
+        raising=False,
+    )
     client = TestClient(app)
     client.headers.update({"X-API-Key": api_key})
     return client

--- a/tests/test_solve2x2_api.py
+++ b/tests/test_solve2x2_api.py
@@ -1,7 +1,9 @@
 def test_solve(api_client):
-    js = api_client.post(
+    resp = api_client.post(
         "/api/solve2x2", json={"a": 1, "b": 1, "c": 2, "d": -1, "e": 4, "f": 0}
-    ).json()
+    )
+    assert resp.status_code == 200
+    js = resp.json()
     assert abs(1 * js["x"] + 1 * js["y"] - 4) < 1e-6
 
 


### PR DESCRIPTION
## Summary
- update the solve2x2 API test to assert the HTTP status before checking the response body
- ensure the shared API client fixture forces the in-memory rate limiter fallback during tests

## Testing
- PYTHONPATH=src pytest tests/test_solve2x2_api.py

------
https://chatgpt.com/codex/tasks/task_e_68cc10fc1c7c8329bcc67e4068342ebb