### PR TITLE
Add status assertion to SSE test

### DIFF
--- a/tests/test_sse_api.py
+++ b/tests/test_sse_api.py
@@ -1,25 +1,31 @@
 import json
 import time
 
+import pytest
+
 
 def test_sse(api_client):
     steps = []
     timestamps = []
 
     with api_client.stream("GET", "/api/events/sse") as response:
+        assert response.status_code == 200
         assert "text/event-stream" in response.headers.get("content-type", "")
 
-        for line in response.iter_lines():
-            if not line:
-                continue
-            if isinstance(line, bytes):
-                line = line.decode()
-            if line.startswith("data:"):
-                payload = json.loads(line.split(":", 1)[1].strip())
-                steps.append(payload["step"])
-                timestamps.append(time.monotonic())
-                if len(steps) == 5:
-                    break
+        try:
+            for line in response.iter_lines():
+                if not line:
+                    continue
+                if isinstance(line, bytes):
+                    line = line.decode()
+                if line.startswith("data:"):
+                    payload = json.loads(line.split(":", 1)[1].strip())
+                    steps.append(payload["step"])
+                    timestamps.append(time.monotonic())
+                    if len(steps) == 5:
+                        break
+        except Exception as exc:  # pragma: no cover - defensive error reporting
+            pytest.fail(f"Error while iterating over SSE stream: {exc}")
 
     assert steps == [1, 2, 3, 4, 5]
 


### PR DESCRIPTION
## Summary
- assert that the streaming SSE response returns HTTP 200 before inspecting headers and payload
- wrap the SSE line iterator in a defensive try/except to surface unexpected iteration errors via pytest.fail

## Testing
- PYTHONPATH=src pytest tests/test_sse_api.py *(fails: redis package not installed, RateLimitMiddleware falls back improperly)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1590576883298a8a70d17044562d