### PR TITLE
Refactor e2e API tests to use fixtures

### DIFF
--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -1,34 +1,54 @@
 import os
 
+import pytest
 from fastapi.testclient import TestClient
 
 from cognitive_core import config
-from cognitive_core.api import auth
+from cognitive_core.api import auth, rate_limit
 from cognitive_core.api.main import app
 
-os.environ.setdefault("COG_API_KEY", "e2e-secret")
-API_KEY = os.environ["COG_API_KEY"]
-config.settings = config.Settings(api_key=API_KEY)
-auth.settings = config.settings
 
-client = TestClient(app)
+@pytest.fixture
+def api_key(monkeypatch: pytest.MonkeyPatch) -> str:
+    original_config_settings = config.settings
+    original_auth_settings = auth.settings
 
-
-def _headers() -> dict[str, str]:
-    config.settings = config.Settings(api_key=API_KEY)
+    monkeypatch.setenv("COG_API_KEY", "e2e-secret")
+    monkeypatch.setattr(rate_limit, "RedisBucketLimiter", None, raising=False)
+    api_key = os.environ["COG_API_KEY"]
+    config.settings = config.Settings(api_key=api_key)
     auth.settings = config.settings
-    return {"X-API-Key": API_KEY}
+
+    yield api_key
+
+    config.settings = original_config_settings
+    auth.settings = original_auth_settings
 
 
-def test_health():
-    r = client.get("/api/health", headers=_headers())
-    assert r.status_code == 200 and r.json()["status"] == "ok"
+@pytest.fixture
+def client(api_key: str):
+    with TestClient(app) as test_client:
+        yield test_client
 
 
-def test_dot_endpoint():
-    r = client.post(
+@pytest.fixture
+def auth_headers(api_key: str) -> dict[str, str]:
+    return {"X-API-Key": api_key}
+
+
+def test_health(client: TestClient, auth_headers: dict[str, str]):
+    response = client.get("/api/health", headers=auth_headers)
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_dot_endpoint(client: TestClient, auth_headers: dict[str, str]):
+    response = client.post(
         "/api/dot",
         json={"a": [1, 2], "b": [3, 4]},
-        headers=_headers(),
+        headers=auth_headers,
     )
-    assert r.status_code == 200 and r.json()["result"] == 11.0
+
+    assert response.status_code == 200
+    assert response.json()["result"] == 11.0


### PR DESCRIPTION
## Summary
- refactor the e2e API tests to configure the API key and FastAPI TestClient via pytest fixtures, ensuring settings and rate limiter dependencies are isolated per test
- simplify assertions by checking response status codes and payloads separately for clearer failures

## Testing
- PYTHONPATH=src pytest tests/e2e/test_api.py

------
https://chatgpt.com/codex/tasks/task_e_68cc1592eb48832985250e06c6297518