### PR TITLE
Use monkeypatch for DATABASE_URL in migration test

### DIFF
--- a/tests/db/test_migrations.py
+++ b/tests/db/test_migrations.py
@@ -14,11 +14,11 @@ except ModuleNotFoundError:  # pragma: no cover - skip if SQLAlchemy unavailable
     pytest.skip("sqlalchemy is not installed", allow_module_level=True)
 
 
-def test_alembic_upgrade_head(tmp_path):
+def test_alembic_upgrade_head(tmp_path, monkeypatch):
     """Run Alembic migrations and ensure tables are created."""
 
     db_url = f"sqlite:///{tmp_path/'test.sqlite'}"
-    os.environ["DATABASE_URL"] = db_url
+    monkeypatch.setenv("DATABASE_URL", db_url)
 
     cfg = Config("alembic.ini")
     command.upgrade(cfg, "head")


### PR DESCRIPTION
## Summary
- use pytest's monkeypatch fixture in the Alembic migration test so DATABASE_URL is restored after the test

## Testing
- PYTHONPATH=src pytest tests/db/test_migrations.py

------
https://chatgpt.com/codex/tasks/task_e_68cc15937c0c8329acd7c8b3cf0554b0