### PR TITLE
Tighten CLI integration failure handling

### DIFF
--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -14,30 +14,60 @@ def _run(cmd: str):
 
 @pytest.mark.integration
 def test_cli_ping():
+    invoked = False
+    errors = []
     for exe in ("cogctl", "python -m cognitive_core.cli"):
-        rc, out, _ = _run(f"{exe} ping")
+        rc, out, err = _run(f"{exe} ping")
+        if rc is None:
+            continue
+        invoked = True
         if rc == 0 and out:
             assert out.strip() == "pong"
             return
+        if rc != 0:
+            errors.append(f"{exe}: {err or out}")
+    if invoked:
+        if errors:
+            pytest.fail("; ".join(errors))
+        pytest.fail("CLI ran but did not return expected output")
     pytest.skip("CLI not available")
 
 
 @pytest.mark.integration
 def test_cli_migrate_status():
+    invoked = False
+    errors = []
     for exe in ("cogctl", "python -m cognitive_core.cli"):
-        rc, _, _ = _run(f"{exe} migrate status")
+        rc, _out, err = _run(f"{exe} migrate status")
+        if rc is None:
+            continue
+        invoked = True
         if rc == 0:
             return
+        errors.append(f"{exe}: {err}")
+    if invoked:
+        pytest.fail("; ".join(filter(None, errors)) or "CLI migrate returned unexpected result")
     pytest.skip("CLI migrate not available")
 
 
 @pytest.mark.integration
 def test_cli_pipeline_run():
+    invoked = False
+    errors = []
     for exe in ("cogctl", "python -m cognitive_core.cli"):
-        rc, out, _ = _run(f"{exe} pipeline run --name demo")
+        rc, out, err = _run(f"{exe} pipeline run --name demo")
+        if rc is None:
+            continue
+        invoked = True
         if rc == 0 and out:
             assert "demo" in out
             return
+        if rc != 0:
+            errors.append(f"{exe}: {err or out}")
+    if invoked:
+        if errors:
+            pytest.fail("; ".join(errors))
+        pytest.fail("CLI ran but did not return expected output")
     pytest.skip("CLI not available")
 
 
@@ -45,6 +75,7 @@ def test_cli_pipeline_run():
 def test_cli_dotv_mismatched_vectors():
     expected_message = "Vectors must be the same length"
     invoked = False
+    errors = []
     for exe in ("cogctl", "python -m cognitive_core.cli"):
         rc, out, err = _run(f"{exe} dotv 1,2 3")
         if rc is None:
@@ -54,7 +85,10 @@ def test_cli_dotv_mismatched_vectors():
             message = err or out
             assert expected_message in message
             return
+        errors.append(f"{exe}: {err or out}")
     if not invoked:
         pytest.skip("CLI not available")
+    if errors:
+        pytest.fail("; ".join(errors))
     pytest.fail("CLI did not report mismatched vector lengths")
 


### PR DESCRIPTION
## Summary
- track CLI execution in integration tests to distinguish unavailable commands from failing runs
- fail fast with captured stderr when an invoked CLI exits non-zero while retaining skip semantics for missing binaries

## Testing
- pytest tests/test_cli_integration.py *(fails: ModuleNotFoundError: No module named 'cognitive_core')*

------
https://chatgpt.com/codex/tasks/task_e_68cc1d188fa88329b90bdb774f945c04