### PR TITLE
Use project extras for Docker image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,7 @@ FROM python:3.12-slim
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 WORKDIR /app
 
-RUN pip install --upgrade pip \
-    && pip install --no-cache-dir \
-        requests \
-        httpx \
-        redis \
-        sqlalchemy \
-        alembic \
-        psycopg2-binary \
-        prometheus-client \
-        structlog
+RUN pip install --upgrade pip
 
 ARG APP_USER=appuser
 ARG APP_UID=1000
@@ -28,6 +19,8 @@ RUN set -eux; \
         "${APP_USER}"
 
 COPY --chown=${APP_USER}:${APP_USER} . /app
+
+RUN pip install --no-cache-dir .[api]
 
 RUN set -eux; \
     install -d -m 0755 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,14 @@ dependencies = [
 
 [project.optional-dependencies]
 api = [
-    "httpx>=0.25,<0.29",
     "prometheus-client>=0.20,<0.21",
     "opentelemetry-sdk>=1.24,<2.0",
+    "redis>=5.0,<6.0",
+    "sqlalchemy>=2.0,<3.0",
+    "alembic>=1.13,<2.0",
+    "psycopg2-binary>=2.9,<3.0",
+    "requests>=2.31,<3.0",
+    "pyyaml>=6.0.1,<7.0",
 ]
 test = [
     "pytest>=7.4,<8.0",


### PR DESCRIPTION
## Summary
- update the Dockerfile to install the project using the api extra instead of a hard-coded requirements list
- expand the api optional dependency group so Redis, SQLAlchemy, Alembic, psycopg2, requests, and PyYAML are installed for the container

## Testing
- `docker build -t cognitive-core-engine:latest .` *(fails: docker not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc255924d88329873b7a86d908ee6c