### PR TITLE
Respect proxy headers for rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ curl -H "X-API-Key: your_api_key" http://localhost:8000/api/health
 Параметри обмеження швидкості контролюються змінними `COG_RATE_LIMIT_RPS`
 та `COG_RATE_LIMIT_BURST`.
 
+Якщо сервіс працює за балансувальником (Nginx, Envoy, Kubernetes Ingress тощо),
+увімкніть довіру до проксі-заголовків, аби ліміти розраховувалися за справжніми
+клієнтськими IP-адресами:
+
+```bash
+export COG_TRUST_PROXY_HEADERS=true
+export COG_TRUSTED_PROXY_HEADER=X-Forwarded-For  # або власна назва заголовка
+```
+
+Сервіс зчитує ліву «публічну» адресу з вказаного заголовка та використовує її
+для сегментації rate limit. Якщо жодна адреса не підходить, middleware
+повертається до IP підключеного клієнта.
+
 ### Troubleshooting
 
 - **Відсутні залежності.** Деякі функції потребують додаткових пакетів

--- a/src/cognitive_core/config/settings.py
+++ b/src/cognitive_core/config/settings.py
@@ -24,6 +24,16 @@ class Settings(BaseSettings):
     )
     rate_limit_rps: float = 5.0
     rate_limit_burst: int = 10
+    trust_proxy_headers: bool = Field(
+        default=False,
+        description=(
+            "Whether to trust proxy-provided client IP headers (such as X-Forwarded-For)."
+        ),
+    )
+    trusted_proxy_header: str = Field(
+        default="X-Forwarded-For",
+        description="Header name containing the upstream client IP when trusting proxies.",
+    )
     allowed_origins: list[str] = Field(
         default_factory=list,
         description="List of allowed CORS origins for the public API.",


### PR DESCRIPTION
## Summary
- add trust_proxy_headers and trusted_proxy_header settings for configuring proxy-aware rate limiting
- resolve client IPs from trusted proxy headers before enforcing rate limits and document the feature
- extend rate limit integration tests to cover trusted and untrusted proxy header scenarios

## Testing
- PYTHONPATH=src pytest tests/security/test_rate_limit.py

------
https://chatgpt.com/codex/tasks/task_e_68cc474e3a5c8329bead810ecc151c81