### PR TITLE
Refactor pipeline API to use database-backed services

### DIFF
--- a/src/cognitive_core/api/rate_limit.py
+++ b/src/cognitive_core/api/rate_limit.py
@@ -107,6 +107,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             "refill_per_sec": settings.rate_limit_rps,
         }
         self._limiter_kwargs = limiter_kwargs
+        self.limiter: object | None = None
 
         if RedisBucketLimiter is None:
             reason = _redis_import_error or "redis client not available"
@@ -123,7 +124,8 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             self._swap_to_in_memory(exc)
 
     def _swap_to_in_memory(self, reason: Exception | str | None = None) -> None:
-        if isinstance(self.limiter, InMemoryBucketLimiter):
+        current = getattr(self, "limiter", None)
+        if isinstance(current, InMemoryBucketLimiter):
             return
 
         if reason is not None:

--- a/src/cognitive_core/api/routers/pipelines.py
+++ b/src/cognitive_core/api/routers/pipelines.py
@@ -1,30 +1,41 @@
-from fastapi import APIRouter, Body, HTTPException
-from pydantic import BaseModel
+from fastapi import APIRouter, Body, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
 
 from ...core.agents_router import AgentsRouter
-from ...core.pipeline_executor import PipelineExecutor
+from ...database import SessionLocal, get_session, init_db
 from ...domain.agents import DebateRound
-from ...domain.pipelines import Artifact, Pipeline
+from ...services.pipelines import (
+    PipelineAlreadyExistsError,
+    PipelineNotFoundError,
+    PipelineService,
+)
 from ...utils.telemetry import instrument_route, record_llm_tokens
 
 router = APIRouter()
-
-
-# In-memory registry for demo purposes
-PIPELINES: dict[str, Pipeline] = {}
-
-
-def _sample_step() -> Artifact:
-    return Artifact(name="result", data=1)
-
-
-PIPELINES["sample"] = Pipeline(id="sample", name="Sample", steps=[_sample_step])
-executor = PipelineExecutor()
 agents_router = AgentsRouter()
+
+init_db()
+
+
+def _seed_default_pipeline() -> None:
+    with SessionLocal() as session:
+        service = PipelineService(session)
+        try:
+            service.create_pipeline("Sample")
+        except PipelineAlreadyExistsError:
+            session.rollback()
+
+
+_seed_default_pipeline()
+
+
+class PipelineCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1)
 
 
 class RunRequest(BaseModel):
-    pipeline_id: str
+    pipeline_id: int
 
 
 class DebateRequest(BaseModel):
@@ -33,30 +44,58 @@ class DebateRequest(BaseModel):
     concurrent: bool = False
 
 
+PipelineCreateRequest.model_rebuild()
 RunRequest.model_rebuild()
 DebateRequest.model_rebuild()
 
 
+def _get_service(session: Session = Depends(get_session)) -> PipelineService:
+    return PipelineService(session)
+
+
+@router.get("/v1/pipelines")
+@instrument_route("list_pipelines")
+def list_pipelines(service: PipelineService = Depends(_get_service)):
+    pipelines = service.list_pipelines()
+    return [
+        {"id": pipeline.id, "name": pipeline.name, "steps": service.step_count(pipeline)}
+        for pipeline in pipelines
+    ]
+
+
+@router.post("/v1/pipelines", status_code=status.HTTP_201_CREATED)
+@instrument_route("create_pipeline")
+def create_pipeline(
+    req: PipelineCreateRequest, service: PipelineService = Depends(_get_service)
+):
+    try:
+        pipeline = service.create_pipeline(req.name)
+    except PipelineAlreadyExistsError:
+        raise HTTPException(status_code=409, detail="Pipeline already exists")
+    return {"id": pipeline.id, "name": pipeline.name, "steps": service.step_count(pipeline)}
+
+
 @router.get("/v1/pipelines/{pipeline_id}")
 @instrument_route("get_pipeline")
-def get_pipeline(pipeline_id: str):
-    pipeline = PIPELINES.get(pipeline_id)
-    if not pipeline:
-        raise HTTPException(status_code=404, detail="Pipeline not found")
-    return {"id": pipeline.id, "name": pipeline.name, "steps": len(pipeline.steps)}
+def get_pipeline(pipeline_id: int, service: PipelineService = Depends(_get_service)):
+    try:
+        pipeline = service.get_pipeline(pipeline_id)
+    except PipelineNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Pipeline not found") from exc
+    return {"id": pipeline.id, "name": pipeline.name, "steps": service.step_count(pipeline)}
 
 
 @router.post("/v1/pipelines/run")
 @instrument_route("run_pipeline")
-def run_pipeline(req: RunRequest = Body(...)):
-    pipeline = PIPELINES.get(req.pipeline_id)
-    if not pipeline:
-        raise HTTPException(status_code=404, detail="Pipeline not found")
-    run = executor.execute(pipeline)
+def run_pipeline(req: RunRequest = Body(...), service: PipelineService = Depends(_get_service)):
+    try:
+        run_model, run = service.run_pipeline(req.pipeline_id)
+    except PipelineNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Pipeline not found") from exc
     record_llm_tokens("run_pipeline", len(run.artifacts))
     return {
-        "run_id": run.id,
-        "status": run.status,
+        "run_id": run_model.id,
+        "status": run_model.status,
         "artifacts": [a.name for a in run.artifacts],
     }
 

--- a/src/cognitive_core/database.py
+++ b/src/cognitive_core/database.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+from typing import Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from .db import Base
+
+
+def _create_engine() -> Engine:
+    database_url = os.environ.get("DATABASE_URL", "sqlite://")
+    engine_kwargs: dict[str, object] = {"future": True}
+    connect_args: dict[str, object] = {}
+
+    if database_url.startswith("sqlite"):
+        connect_args["check_same_thread"] = False
+        if database_url in {"sqlite://", "sqlite:///:memory:"}:
+            engine_kwargs["poolclass"] = StaticPool
+
+    return create_engine(database_url, connect_args=connect_args, **engine_kwargs)
+
+
+engine = _create_engine()
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+def init_db() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+def get_session() -> Iterator[Session]:
+    session: Session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/src/cognitive_core/services/__init__.py
+++ b/src/cognitive_core/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer for application business logic."""

--- a/src/cognitive_core/services/pipelines.py
+++ b/src/cognitive_core/services/pipelines.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from ..core.pipeline_executor import PipelineExecutor
+from ..db import Pipeline as PipelineModel, Run as RunModel
+from ..domain.pipelines import Artifact, Pipeline as DomainPipeline, Run as DomainRun
+
+
+class PipelineError(Exception):
+    """Base exception for pipeline service errors."""
+
+
+class PipelineNotFoundError(PipelineError):
+    """Raised when a pipeline does not exist."""
+
+
+class PipelineAlreadyExistsError(PipelineError):
+    """Raised when attempting to create a duplicate pipeline."""
+
+
+@dataclass
+class PipelineRepository:
+    session: Session
+
+    def list(self) -> List[PipelineModel]:
+        return (
+            self.session.query(PipelineModel)
+            .order_by(PipelineModel.id)
+            .all()
+        )
+
+    def get(self, pipeline_id: int) -> PipelineModel | None:
+        return self.session.get(PipelineModel, pipeline_id)
+
+    def get_by_name(self, name: str) -> PipelineModel | None:
+        return self.session.query(PipelineModel).filter_by(name=name).one_or_none()
+
+    def add(self, pipeline: PipelineModel) -> PipelineModel:
+        self.session.add(pipeline)
+        self.session.flush()
+        return pipeline
+
+    def add_run(self, run: RunModel) -> RunModel:
+        self.session.add(run)
+        self.session.flush()
+        return run
+
+
+class PipelineService:
+    """Business logic for pipeline management."""
+
+    def __init__(self, session: Session, executor: PipelineExecutor | None = None):
+        self.session = session
+        self.repository = PipelineRepository(session)
+        self.executor = executor or PipelineExecutor()
+
+    def list_pipelines(self) -> List[PipelineModel]:
+        return self.repository.list()
+
+    def create_pipeline(self, name: str) -> PipelineModel:
+        pipeline = PipelineModel(name=name)
+        self.repository.add(pipeline)
+        try:
+            self.session.commit()
+        except IntegrityError as exc:
+            self.session.rollback()
+            raise PipelineAlreadyExistsError(name) from exc
+        self.session.refresh(pipeline)
+        return pipeline
+
+    def get_pipeline(self, pipeline_id: int) -> PipelineModel:
+        pipeline = self.repository.get(pipeline_id)
+        if pipeline is None:
+            raise PipelineNotFoundError(str(pipeline_id))
+        return pipeline
+
+    def run_pipeline(self, pipeline_id: int) -> Tuple[RunModel, DomainRun]:
+        pipeline = self.get_pipeline(pipeline_id)
+        run_model = RunModel(pipeline_id=pipeline.id, status="running")
+        self.repository.add_run(run_model)
+
+        domain_pipeline = self._to_domain_pipeline(pipeline)
+        try:
+            domain_run = self.executor.execute(domain_pipeline)
+        except Exception:
+            self.session.rollback()
+            raise
+
+        run_model.status = domain_run.status
+        self.session.commit()
+        self.session.refresh(run_model)
+        return run_model, domain_run
+
+    def step_count(self, pipeline: PipelineModel) -> int:
+        return len(self._build_steps(pipeline))
+
+    def _to_domain_pipeline(self, pipeline: PipelineModel) -> DomainPipeline:
+        return DomainPipeline(
+            id=str(pipeline.id),
+            name=pipeline.name,
+            steps=self._build_steps(pipeline),
+        )
+
+    def _build_steps(self, pipeline: PipelineModel) -> List:
+        def _step() -> Artifact:
+            return Artifact(name="result", data=1)
+
+        _step.__name__ = "result"
+        return [_step]

--- a/tests/test_pipelines_api.py
+++ b/tests/test_pipelines_api.py
@@ -1,16 +1,43 @@
-def test_get_pipeline(api_client):
-    resp = api_client.get("/api/v1/pipelines/sample")
-    assert resp.status_code == 200, resp.text
-    data = resp.json()
-    assert data["id"] == "sample"
+import uuid
 
 
-def test_run_pipeline(api_client):
-    resp = api_client.post("/api/v1/pipelines/run", json={"pipeline_id": "sample"})
+def test_list_pipelines_includes_seeded_sample(api_client):
+    resp = api_client.get("/api/v1/pipelines")
     assert resp.status_code == 200, resp.text
-    data = resp.json()
-    assert data["status"] == "completed"
-    assert data["artifacts"] == ["result"]
+    pipelines = resp.json()
+    assert any(p["name"] == "Sample" for p in pipelines)
+
+
+def test_create_pipeline_and_fetch(api_client):
+    name = f"Pipeline-{uuid.uuid4()}"
+    create_resp = api_client.post("/api/v1/pipelines", json={"name": name})
+    assert create_resp.status_code == 201, create_resp.text
+    pipeline = create_resp.json()
+    assert pipeline["name"] == name
+    assert pipeline["steps"] == 1
+
+    get_resp = api_client.get(f"/api/v1/pipelines/{pipeline['id']}")
+    assert get_resp.status_code == 200, get_resp.text
+    fetched = get_resp.json()
+    assert fetched == pipeline
+
+
+def test_run_pipeline_creates_completed_run(api_client):
+    name = f"Runnable-{uuid.uuid4()}"
+    pipeline_id = api_client.post("/api/v1/pipelines", json={"name": name}).json()["id"]
+
+    run_resp = api_client.post("/api/v1/pipelines/run", json={"pipeline_id": pipeline_id})
+    assert run_resp.status_code == 200, run_resp.text
+    run_data = run_resp.json()
+    assert isinstance(run_data["run_id"], int)
+    assert run_data["status"] == "completed"
+    assert run_data["artifacts"] == ["result"]
+
+
+def test_run_pipeline_missing_returns_404(api_client):
+    run_resp = api_client.post("/api/v1/pipelines/run", json={"pipeline_id": 9999})
+    assert run_resp.status_code == 404
+    assert run_resp.json()["detail"] == "Pipeline not found"
 
 
 def test_aots_debate_missing_role_returns_404(api_client):


### PR DESCRIPTION
## Summary
- introduce a SQLAlchemy session helper and pipeline service that persists pipeline and run records
- replace the in-memory pipeline router with database-backed list/create/run endpoints and seed a default pipeline
- harden the rate limit middleware fallback when Redis is unavailable and update API tests for the persistent behaviour

## Testing
- PYTHONPATH=src pytest tests/test_pipelines_api.py


------
https://chatgpt.com/codex/tasks/task_e_68cc88ee8d1083298eb72564297b4e85