### PR TITLE
Implement CLI pipeline execution and update integration test

### DIFF
--- a/src/cognitive_core/cli.py
+++ b/src/cognitive_core/cli.py
@@ -3,14 +3,90 @@
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
 import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any, Iterable, Mapping
 
 from .app.services import dot as dot_service
 from .core.math_utils import solve_2x2
+from .core.pipeline_executor import PipelineExecutor
+from .domain.pipelines import Pipeline, Run
+
+
+def _make_json_safe(value: Any) -> Any:
+    """Recursively convert ``value`` into something JSON serialisable."""
+
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, list | tuple):
+        return [_make_json_safe(item) for item in value]
+    if isinstance(value, Mapping):
+        return {key: _make_json_safe(item) for key, item in value.items()}
+    return repr(value)
+
+
+def _format_run_result(pipeline: Pipeline, run: Run) -> dict[str, Any]:
+    """Generate structured execution details for CLI output."""
+
+    return {
+        "pipeline": {"id": pipeline.id, "name": pipeline.name},
+        "run": {
+            "id": run.id,
+            "status": run.status,
+            "artifacts": [
+                {
+                    "name": artifact.name,
+                    "data": _make_json_safe(artifact.data),
+                }
+                for artifact in run.artifacts
+            ],
+            "events": [
+                {
+                    "step": event.step,
+                    "type": event.type,
+                    "timestamp": event.timestamp,
+                }
+                for event in run.events
+            ],
+        },
+    }
+
+
+def _load_pipeline_registry() -> Iterable[Mapping[str, Pipeline]]:
+    """Load pipeline registries configured for CLI execution."""
+
+    registries: list[Mapping[str, Pipeline]] = []
+    module_path = os.environ.get("COGNITIVE_CORE_PIPELINE_REGISTRY")
+    if module_path:
+        module = importlib.import_module(module_path)
+        registry = getattr(module, "PIPELINES", None)
+        if not isinstance(registry, Mapping):
+            raise LookupError(
+                "Configured pipeline registry must expose a mapping named PIPELINES"
+            )
+        registries.append(registry)
+
+    from .api.routers import pipelines as pipeline_router
+
+    registries.append(pipeline_router.PIPELINES)
+    return registries
+
+
+def _resolve_pipeline(name: str) -> Pipeline:
+    """Return a pipeline by id or display name."""
+
+    for registry in _load_pipeline_registry():
+        pipeline = registry.get(name)
+        if pipeline is not None:
+            return pipeline
+        for candidate in registry.values():
+            if candidate.name == name:
+                return candidate
+    raise LookupError(f"Pipeline '{name}' not found")
 
 
 def _run_alembic(*args: str) -> int:
@@ -124,7 +200,15 @@ def handle_args(args: argparse.Namespace) -> int:
         return 1
 
     if args.cmd == "pipeline" and args.action == "run":
-        print(f"Running pipeline {args.name}")
+        try:
+            pipeline = _resolve_pipeline(args.name)
+        except LookupError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        executor = PipelineExecutor()
+        run = executor.execute(pipeline)
+        result = _format_run_result(pipeline, run)
+        print(json.dumps(result))
         return 0
 
     if args.cmd == "plugin":

--- a/tests/pipeline_registry_stub.py
+++ b/tests/pipeline_registry_stub.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from cognitive_core.domain.pipelines import Artifact, Pipeline
+
+
+def _demo_step() -> Artifact:
+    return Artifact(name="demo_step", data={"value": 42})
+
+
+PIPELINES = {
+    "demo": Pipeline(id="demo", name="Demo", steps=[_demo_step])
+}


### PR DESCRIPTION
## Summary
- resolve pipelines via a configurable registry and execute them through the `PipelineExecutor` in the CLI
- emit structured JSON run results including artifacts and events from pipeline execution
- add a stub pipeline registry and update the CLI integration test to parse JSON output for hermetic verification

## Testing
- `PYTHONPATH=src pytest tests/test_cli_integration.py::test_cli_pipeline_run`


------
https://chatgpt.com/codex/tasks/task_e_68cd46d444308329b6bcecb92df4e546