### PR TITLE
chore: remove typing-extensions dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.7,<3.0",
     "pydantic-settings>=2.0,<3.0",
-    "typing-extensions>=4.8,<5.0",
     "fastapi>=0.111,<0.120",
     "uvicorn>=0.29,<0.36",
     "httpx>=0.25,<0.29",

--- a/requirements.lock
+++ b/requirements.lock
@@ -9,7 +9,6 @@
 # (The actual lock should contain exact versions with --hash entries.)
 
 pydantic>=2.7,<3.0
-typing-extensions>=4.8,<5.0
 fastapi>=0.111,<0.120
 uvicorn>=0.29,<0.36
 httpx>=0.25,<0.29

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # Core runtime dependencies
 pydantic>=2.7,<3.0
 pydantic-settings>=2.0,<3.0
-typing-extensions>=4.8,<5.0
 fastapi>=0.111,<0.120
 uvicorn>=0.29,<0.36
 httpx>=0.25,<0.29


### PR DESCRIPTION
## Summary
- remove the unused typing-extensions requirement from the core project metadata
- refresh requirements.txt and the placeholder lock file to keep dependency manifests aligned

## Testing
- `pip install -e .` *(fails: build dependency setuptools>=68,<70 cannot be downloaded in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd665580f48329bf1fbb8731ab58c0