### PR TITLE
Add pydantic-settings placeholder entry

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -9,6 +9,7 @@
 # (The actual lock should contain exact versions with --hash entries.)
 
 pydantic>=2.7,<3.0
+pydantic-settings>=2.0,<3.0
 typing-extensions>=4.8,<5.0
 fastapi>=0.111,<0.120
 uvicorn>=0.29,<0.36


### PR DESCRIPTION
## Summary
- add the pydantic-settings requirement to the offline placeholder lock file

## Testing
- ⚠️ `python -m pip install --upgrade pip pip-tools` *(fails: network proxy blocks package downloads in this environment)*
- ⚠️ `. /tmp/locktest/bin/activate && pip install -r requirements.lock` *(fails: network proxy blocks package downloads in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6655ecbc8329a4d1485b9bb33ed0