### PR TITLE
Ensure reports directory exists before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
           restore-keys: ${{ runner.os }}-go-
       - name: Vet
         run: go vet ./...
+      - run: mkdir -p reports
       - name: Test
         run: go test ./... -coverprofile=cover.out -json > reports/go-test.json
       - name: Coverage
@@ -223,6 +224,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings || true
+      - run: mkdir -p reports
       - name: Test
         run: cargo test --all -- --format=json --report-time | tee reports/rust-test.json
       - name: Coverage


### PR DESCRIPTION
## Summary
- create the reports directory in the Go workflow before running tests or other report-producing steps
- pre-create the reports directory in the Rust workflow before capturing test output for future Rust support

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd95afe2ec83299976bd1b5d7404fe