### PR TITLE
Add API key support for remote pipeline runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ cogctl pipeline run --name sample --api-url http://localhost:8000
 # або експортуйте COGCORE_API_URL, щоб уникнути передачі параметра щоразу
 export COGCORE_API_URL=http://localhost:8000
 cogctl pipeline run --name sample
+
+# Для аутентифікації CLI може використовувати окремий ключ
+export COGCTL_API_KEY=your_cli_api_key
+# Або повторно використовуйте основний ключ API
+export COG_API_KEY=your_api_key
 ```
 
 > **Примітка.** Для віддаленого запуску необхідний працюючий сервіс `cognitive-core` з ввімкненим маршрутом `POST /api/v1/pipelines/run`. У режимі локального виконання CLI використовує вбудований реєстр пайплайнів і виконує їх через `PipelineExecutor` без звернення до мережі.

--- a/src/cognitive_core/cli.py
+++ b/src/cognitive_core/cli.py
@@ -88,8 +88,15 @@ def _run_pipeline_remotely(name: str, api_url: str) -> dict[str, Any]:
     import httpx
 
     endpoint = f"{api_url.rstrip('/')}/api/v1/pipelines/run"
+    api_key = os.environ.get("COGCTL_API_KEY") or os.environ.get("COG_API_KEY")
+    headers = {"X-API-Key": api_key} if api_key else None
     try:
-        response = httpx.post(endpoint, json={"pipeline_id": name}, timeout=10.0)
+        response = httpx.post(
+            endpoint,
+            json={"pipeline_id": name},
+            timeout=10.0,
+            headers=headers,
+        )
     except httpx.HTTPError as exc:
         raise PipelineError(f"Failed to contact pipeline API at {endpoint}: {exc}") from exc
 


### PR DESCRIPTION
## Summary
- load an API key for remote pipeline runs from COGCTL_API_KEY or COG_API_KEY
- attach the key to http requests as the X-API-Key header
- document how to configure the CLI authentication key in the README

## Testing
- PYTHONPATH=src pytest tests/cli/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cda1d578688329927d65472af72149