### PR TITLE
Register demo pipeline and align CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,18 +152,20 @@ cogctl dotv 1,2,3 4,5,6
 cogctl solve2x2 1 2 3 4 5 6
 # -> {"x": -4.0, "y": 4.5}
 
-# Запуск пайплайна з локального реєстру
-cogctl pipeline run --name sample
-# -> {"run_id": "...", "status": "completed", "artifacts": ["result"]}
+# Запуск демо-пайплайна з локального реєстру
+cogctl pipeline run --name demo
+# -> {"run_id": "...", "status": "completed", "artifacts": ["demo"]}
 
 # Виконання через API (потрібен запущений бекенд на http://localhost:8000)
-cogctl pipeline run --name sample --api-url http://localhost:8000
+cogctl pipeline run --name demo --api-url http://localhost:8000
 # або експортуйте COGCORE_API_URL, щоб уникнути передачі параметра щоразу
 export COGCORE_API_URL=http://localhost:8000
-cogctl pipeline run --name sample
+cogctl pipeline run --name demo
 ```
 
 > **Примітка.** Для віддаленого запуску необхідний працюючий сервіс `cognitive-core` з ввімкненим маршрутом `POST /api/v1/pipelines/run`. У режимі локального виконання CLI використовує вбудований реєстр пайплайнів і виконує їх через `PipelineExecutor` без звернення до мережі.
+
+> **Tip.** Тестовий пайплайн `sample` усе ще доступний для внутрішніх тестів CLI і повертає артефакт `result`.
 
 ## Тестування
 

--- a/src/cognitive_core/pipelines/registry.py
+++ b/src/cognitive_core/pipelines/registry.py
@@ -33,3 +33,12 @@ def _sample_step() -> Artifact:
 
 
 register_pipeline(Pipeline(id="sample", name="Sample", steps=[_sample_step]))
+
+
+def _demo_step() -> Artifact:
+    """Return a simple artifact used by the demo pipeline."""
+
+    return Artifact(name="demo", data={"message": "hello from demo"})
+
+
+register_pipeline(Pipeline(id="demo", name="Demo", steps=[_demo_step]))


### PR DESCRIPTION
## Summary
- register a demo pipeline alongside the existing sample definition
- return a named artifact from the demo step so CLI output includes the pipeline identifier
- refresh the README CLI examples to highlight the demo pipeline while noting sample remains for tests

## Testing
- PYTHONPATH=src pytest tests/test_cli_integration.py


------
https://chatgpt.com/codex/tasks/task_e_68cda1d3dd9483298e3a557f28465501