### PR TITLE
Document API key header requirements

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,13 +1,12 @@
 # API
 
-> **Security requirement:** перед тим як викликати ендпоінти, встановіть
-> середовищну змінну `COG_API_KEY`. Якщо ключ не налаштовано або він порожній,
-> сервер відповідає помилкою `500` й відхиляє запити.
+> **Security requirement:** перед тим як викликати ендпоінти, встановіть середовищну змінну `COG_API_KEY` і передавайте її значення у кожному запиті через заголовок `X-API-Key`. Якщо ключ не налаштовано або він порожній, сервер відповідає помилкою `500`. Якщо заголовок відсутній або містить некоректне значення, сервер повертає `403 Forbidden`.
 
 ## GET /api/health
 Request:
 ```http
 GET /api/health HTTP/1.1
+X-API-Key: <your-api-key>
 ```
 Response:
 ```json
@@ -21,6 +20,7 @@ Request:
 ```http
 POST /api/dot HTTP/1.1
 Content-Type: application/json
+X-API-Key: <your-api-key>
 
 {
   "a": [1, 2, 3],
@@ -39,6 +39,7 @@ Request:
 ```http
 POST /api/solve2x2 HTTP/1.1
 Content-Type: application/json
+X-API-Key: <your-api-key>
 
 {
   "a": 1,
@@ -59,6 +60,12 @@ Response:
 
 ## GET /api/events/sse
 Server-Sent Events stream providing real-time messages.
+Request:
+```http
+GET /api/events/sse HTTP/1.1
+Accept: text/event-stream
+X-API-Key: <your-api-key>
+```
 Response:
 ```text
 data: hello


### PR DESCRIPTION
## Summary
- document that all API requests must include the X-API-Key header
- update every sample request to show the required header and mention the 403 response for missing or invalid keys

## Testing
- mkdocs build *(fails: mkdocs not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce0172051483299294eae128124ca9