### PR TITLE
Secure systemd service configuration

### DIFF
--- a/deployment/cognitive_core.service
+++ b/deployment/cognitive_core.service
@@ -1,4 +1,3 @@
-
 [Unit]
 Description=Cognitive Core API
 After=network.target
@@ -7,13 +6,9 @@ After=network.target
 User=www-data
 Group=www-data
 WorkingDirectory=/opt/cognitive-core
-Environment=DATABASE_URL=postgresql+psycopg2://cce:cce@localhost:5432/cce
-Environment=REDIS_URL=redis://localhost:6379/0
-Environment=COG_API_KEY=changeme
-Environment=COG_APP_NAME=Cognitive Core Engine
-Environment=COG_API_PREFIX=/api
-Environment=COG_RATE_LIMIT_RPS=5
-Environment=COG_RATE_LIMIT_BURST=10
+# Load secrets and runtime configuration from a dedicated environment file.
+# See docs/operations.md for details on generating secure values.
+EnvironmentFile=/etc/cognitive-core.env
 ExecStart=/opt/cognitive-core/.venv/bin/uvicorn cognitive_core.api.main:app --host 0.0.0.0 --port 8000
 Restart=on-failure
 RestartSec=5s

--- a/tests/deployment/test_service_file.py
+++ b/tests/deployment/test_service_file.py
@@ -1,0 +1,19 @@
+"""Checks for deployment unit file hygiene."""
+from __future__ import annotations
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SERVICE_PATH = PROJECT_ROOT / "deployment" / "cognitive_core.service"
+
+
+def test_service_loads_external_environment_file() -> None:
+    contents = SERVICE_PATH.read_text(encoding="utf-8")
+    assert "EnvironmentFile=" in contents, "Service should load secrets from an external environment file."
+
+
+def test_service_does_not_embed_placeholder_secrets() -> None:
+    contents = SERVICE_PATH.read_text(encoding="utf-8")
+    forbidden_tokens = {"changeme", "COG_API_KEY="}
+    for token in forbidden_tokens:
+        assert token not in contents, f"Service file should not include placeholder secret '{token}'."


### PR DESCRIPTION
## Summary
- load systemd unit configuration from an external environment file instead of hard-coded secrets
- document systemd deployment workflow and highlight the need for a strong API key before enabling the service
- add a smoke test that ensures the unit file requires an environment file and no longer embeds placeholder credentials

## Testing
- PYTHONPATH=src pytest tests/deployment/test_service_file.py

------
https://chatgpt.com/codex/tasks/task_e_68ce564b6a888329a08b5e6b03240031