### PR TITLE
Centralize package version discovery

### DIFF
--- a/src/cognitive_core/__init__.py
+++ b/src/cognitive_core/__init__.py
@@ -1,1 +1,27 @@
-__version__ = "0.1.0"
+from __future__ import annotations
+
+import re
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+
+
+def _read_version_from_pyproject() -> str:
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    if pyproject_path.is_file():
+        text = pyproject_path.read_text(encoding="utf-8")
+        match = re.search(r'^version\s*=\s*"(?P<version>[^"]+)"', text, re.MULTILINE)
+        if match:
+            return match.group("version")
+    raise RuntimeError("Unable to determine package version from pyproject.toml")
+
+
+def _discover_version() -> str:
+    try:
+        return importlib_metadata.version("cognitive-core-engine")
+    except importlib_metadata.PackageNotFoundError:
+        return _read_version_from_pyproject()
+
+
+__version__ = _discover_version()
+
+__all__ = ["__version__"]

--- a/src/cognitive_core/cli.py
+++ b/src/cognitive_core/cli.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 from typing import Any, Iterable
 
+from . import __version__
 from .app.services import dot as dot_service
 from .core.math_utils import solve_2x2
 from .core.pipeline_executor import PipelineExecutor
@@ -164,6 +165,7 @@ def _run_pipeline(name: str, api_url: str | None) -> dict[str, Any]:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="cogctl")
+    parser.add_argument("-V", "--version", action="version", version=f"%(prog)s {__version__}")
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     # basic math helpers kept for compatibility

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import re
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+
+import pytest
+
+import cognitive_core
+from cognitive_core import cli
+
+
+def _read_pyproject_version() -> str:
+    root = Path(__file__).resolve().parents[1]
+    pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"(?P<version>[^"]+)"', pyproject, re.MULTILINE)
+    assert match, "pyproject.toml is missing a [project] version field"
+    return match.group("version")
+
+
+def test_package_version_matches_pyproject() -> None:
+    expected = _read_pyproject_version()
+    assert cognitive_core.__version__ == expected
+
+    try:
+        dist_version = importlib_metadata.version("cognitive-core-engine")
+    except importlib_metadata.PackageNotFoundError:
+        dist_version = None
+
+    if dist_version is not None:
+        assert dist_version == expected
+
+
+def test_cli_version_flag_reports_expected_value(capsys: pytest.CaptureFixture[str]) -> None:
+    expected = _read_pyproject_version()
+    parser = cli.build_parser()
+
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["--version"])
+
+    assert exc.value.code == 0
+    out, err = capsys.readouterr()
+    assert err == ""
+    assert expected in out


### PR DESCRIPTION
## Summary
- load the cognitive-core-engine version via importlib metadata with a pyproject fallback
- expose the release number through the cogctl --version flag
- add tests that keep the package metadata and CLI output aligned with pyproject.toml

## Testing
- PYTHONPATH=src pytest tests/test_version.py

------
https://chatgpt.com/codex/tasks/task_e_68ce584052c08329b49566e8c72f2d80