### PR TITLE
docs: add v0.1.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.1.1 — 2025-09-20
+- Bundled pipeline packages and their registry in the distribution manifest so published wheels include runnable flows out of the box.
+- Added an opt-in console OpenTelemetry exporter with configuration docs and regression coverage for local diagnostics.
+- Tightened pipeline tooling by propagating `pipeline_id` in run results and enabling remote runs to pass API keys from the CLI.
+- Cached agent role lookups to avoid repeatedly reading pipeline metadata during routing.
+- Hardened deployment and security by dropping baked-in API keys from the systemd unit and redacting secrets in rate limiter logs.
+- Improved vector memory adapters to reuse prepared statements and trim result parsing overhead.
+
 ## v0.1.0 — 2025-09-12
 - Unified version to v0.1.0 across code and docs.
 - Moved runtime deps into `pyproject.toml`; thinned `requirements.txt` to `-e .[dev]`.


### PR DESCRIPTION
## Summary
- add a v0.1.1 changelog entry summarizing the latest manifest, telemetry, pipeline, caching, security, and memory improvements

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ce584374508329aad520370bffd305