### PR TITLE
Update CLI pipeline output docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ cogctl solve2x2 1 2 3 4 5 6
 
 # Запуск пайплайна з локального реєстру
 cogctl pipeline run --name sample
-# -> {"run_id": "...", "status": "completed", "artifacts": ["result"]}
+# -> {"pipeline_id": "sample", "run_id": "...", "status": "completed", "artifacts": ["result"]}
 
 # Виконання через API (потрібен запущений бекенд на http://localhost:8000)
 cogctl pipeline run --name sample --api-url http://localhost:8000


### PR DESCRIPTION
## Summary
- update the README CLI snippet to include pipeline_id in pipeline run output
- verified no other CLI docs referenced the old schema

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce7b8e36b8832996c95b1bf77655f4