### PR TITLE
Document API key usage in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ from cognitive_core.app.services import dot
 result = dot([1, 2, 3], [4, 5, 6])
 print(result)
 PY` | `32.0` у стандартному виводі |
-| Перевірити API | `curl -s http://localhost:8000/api/health` | `{ "status": "ok" }` |
+| Перевірити API | `curl -s -H "X-API-Key: $COG_API_KEY" http://localhost:8000/api/health` | `{ "status": "ok" }` |
 
 > **Порада.** У CLI та HTTP API доступні й інші пайплайни (розв'язувач систем, нормалізація векторів тощо). Скористайтесь `cogctl --help` або відкрийте [інтерактивну документацію FastAPI](http://localhost:8000/docs), щоб переглянути повний перелік доступних команд та маршрутів.
 
@@ -85,11 +85,12 @@ docker run --rm -p 8000:8000 cognitive-core:local
 
 ```bash
 # Перевірка стану сервісу
-curl -s http://localhost:8000/api/health
+curl -s -H "X-API-Key: $COG_API_KEY" http://localhost:8000/api/health
 # -> {"status": "ok"}
 
 # Обчислення скалярного добутку
 curl -s -X POST http://localhost:8000/api/dot \
+  -H "X-API-Key: $COG_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"a": [1, 2, 3], "b": [4, 5, 6]}'
 # -> {"result": 32.0}


### PR DESCRIPTION
## Summary
- update the quick-start health probe example to send the X-API-Key header
- align the API section curl snippets with the documented authentication requirement

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68ce7b8e6b108329bbeed2ee58180483