### PR TITLE
Require API key for remote pipeline runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,15 +162,11 @@ cogctl pipeline run --name sample
 # -> {"pipeline_id": "sample", "run_id": "...", "status": "completed", "artifacts": ["result"]}
 
 # Виконання через API (потрібен запущений бекенд на http://localhost:8000)
+export COGCTL_API_KEY=your_cli_api_key  # або використовуйте COG_API_KEY для основного ключа
 cogctl pipeline run --name sample --api-url http://localhost:8000
 # або експортуйте COGCORE_API_URL, щоб уникнути передачі параметра щоразу
 export COGCORE_API_URL=http://localhost:8000
 cogctl pipeline run --name sample
-
-# Для аутентифікації CLI може використовувати окремий ключ
-export COGCTL_API_KEY=your_cli_api_key
-# Або повторно використовуйте основний ключ API
-export COG_API_KEY=your_api_key
 ```
 
 > **Примітка.** Для віддаленого запуску необхідний працюючий сервіс `cognitive-core` з ввімкненим маршрутом `POST /api/v1/pipelines/run`. У режимі локального виконання CLI використовує вбудований реєстр пайплайнів і виконує їх через `PipelineExecutor` без звернення до мережі.

--- a/src/cognitive_core/cli.py
+++ b/src/cognitive_core/cli.py
@@ -127,7 +127,11 @@ def _run_pipeline_remotely(name: str, api_url: str) -> dict[str, Any]:
 
     endpoint = f"{api_url.rstrip('/')}/api/v1/pipelines/run"
     api_key = os.environ.get("COGCTL_API_KEY") or os.environ.get("COG_API_KEY")
-    headers = {"X-API-Key": api_key} if api_key else None
+    if not api_key:
+        raise PipelineError(
+            "Remote pipeline execution requires an API key. Set COGCTL_API_KEY or COG_API_KEY."
+        )
+    headers = {"X-API-Key": api_key}
     try:
         response = httpx.post(
             endpoint,
@@ -192,7 +196,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_run.add_argument("--name", required=True)
     p_run.add_argument(
         "--api-url",
-        help="Base URL of a running cognitive-core API service. If omitted, the CLI runs pipelines using local definitions.",
+        help=(
+            "Base URL of a running cognitive-core API service. If omitted, the CLI runs pipelines using local definitions. "
+            "Remote execution requires COGCTL_API_KEY or COG_API_KEY to be set."
+        ),
     )
 
     p_plugin = sub.add_parser("plugin")

--- a/tests/cli/test_cli_remote.py
+++ b/tests/cli/test_cli_remote.py
@@ -1,0 +1,55 @@
+import pytest
+
+from cognitive_core import cli
+
+
+class _DummyResponse:
+    status_code = 200
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return {
+            "pipeline_id": "sample",
+            "run_id": "remote-run",
+            "status": "queued",
+            "artifacts": [],
+        }
+
+
+def test_run_pipeline_remotely_requires_api_key(monkeypatch):
+    monkeypatch.delenv("COGCTL_API_KEY", raising=False)
+    monkeypatch.delenv("COG_API_KEY", raising=False)
+
+    with pytest.raises(cli.PipelineError):
+        cli._run_pipeline_remotely("sample", "http://example.com")
+
+
+def test_run_pipeline_remotely_sends_api_key_header(monkeypatch):
+    monkeypatch.setenv("COGCTL_API_KEY", "cli-secret")
+    monkeypatch.delenv("COG_API_KEY", raising=False)
+
+    calls: dict = {}
+
+    def fake_post(url, *, json, timeout, headers):
+        calls["url"] = url
+        calls["json"] = json
+        calls["timeout"] = timeout
+        calls["headers"] = headers
+        return _DummyResponse()
+
+    monkeypatch.setattr("httpx.post", fake_post)
+
+    result = cli._run_pipeline_remotely("sample", "http://api.local")
+
+    assert calls["url"].endswith("/api/v1/pipelines/run")
+    assert calls["json"] == {"pipeline_id": "sample"}
+    assert calls["timeout"] == 10.0
+    assert calls["headers"] == {"X-API-Key": "cli-secret"}
+    assert result == {
+        "pipeline_id": "sample",
+        "run_id": "remote-run",
+        "status": "queued",
+        "artifacts": [],
+    }


### PR DESCRIPTION
## Summary
- require an API key for remote pipeline execution and send it via the `X-API-Key` header
- clarify CLI documentation about exporting API keys for remote calls
- add tests covering API key validation and header propagation

## Testing
- PYTHONPATH=src pytest tests/cli/test_cli_remote.py

------
https://chatgpt.com/codex/tasks/task_e_68ce9b6ede0c832993522dc3433168a7