### PR TITLE
Fix manifest migration reference

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -5,7 +5,7 @@
     "README.md",
     "alembic.ini",
     "alembic/env.py",
-    "alembic/versions/0001_init.py",
+    "alembic/versions/0001_initial.py",
     "config/agents/critic.yaml",
     "config/agents/proponent.yaml",
     "mkdocs.yml",


### PR DESCRIPTION
## Summary
- correct the Alembic migration path recorded in `MANIFEST.json`
- ensure the manifest still enumerates the full `tests/` matrix for packaging

## Testing
- ⚠️ `python -m build` *(fails: module `build` is unavailable in the execution environment due to restricted package index access)*

------
https://chatgpt.com/codex/tasks/task_e_68cebd267be88329a87b5df820cffee4